### PR TITLE
feat(xf): add SplitMixRGB continuation API

### DIFF
--- a/src/Gay.jl
+++ b/src/Gay.jl
@@ -363,10 +363,10 @@ include("enzyme_dsl.jl")
 include("okhsl_learnable.jl")
 using .OkhslLearnable: LearnableColorSpace, LearnableOkhsl, LearnableSeedMap
 using .OkhslLearnable: forward_color, learn_colorspace!, compute_loss
-using .OkhslLearnable: EnzymeColorState, enzyme_color_gradient, demo_learnable_okhsl
+using .OkhslLearnable: EnzymeColorState, enzyme_color_gradient, world_learnable_okhsl
 export LearnableColorSpace, LearnableOkhsl, LearnableSeedMap
 export forward_color, learn_colorspace!, compute_loss
-export EnzymeColorState, enzyme_color_gradient, demo_learnable_okhsl
+export EnzymeColorState, enzyme_color_gradient, world_learnable_okhsl
 
 # Include energy measurement (Apple Silicon powermetrics)
 include("energy.jl")
@@ -378,27 +378,27 @@ include("semiosis.jl")
 # using .TracedTensor
 # export TracedMorphism, tensor_product, monoidal_unit, categorical_trace
 # export feedback_loop, TensorNetwork, add_node!, add_edge!, run_network!
-# export verify_traced_laws, demo_traced_tensor, network_fingerprint
+# export verify_traced_laws, world_traced_tensor, network_fingerprint
 
 # TODO: include("thread_findings.jl")
 # using .ThreadFindings
 # export Finding, FindingsSet, ThreadContext, VerificationMonad
 # export bind_finding, return_finding, run_verification
 # export count_threads, fingerprint_threads, lazy_place!
-# export demo_thread_findings, LazyThreadStream, next_thread!, LAYER_NAMES
+# export world_thread_findings, LazyThreadStream, next_thread!, LAYER_NAMES
 # export run_all_verifications
 
 # TODO: include("verification_report.jl")
 # using .VerificationReport
 # export generate_report, FullReport, ReportSection
 # export verify_coherence, attestation_fingerprint
-# export export_report_markdown, demo_report
+# export export_report_markdown, world_report
 
 # TODO: include("amp_threads.jl")
 # using .AmpThreads
 # export AmpThread, thread_seed, thread_color, thread_fingerprint
 # export ThreadGenealogy, add_thread!, genealogy_fingerprint
-# export verify_thread_chain, demo_amp_threads
+# export verify_thread_chain, world_amp_threads
 
 # TODO: include("cognitive_superposition.jl") — depends on TracedTensor (missing)
 # using .CognitiveSuperposition
@@ -406,7 +406,7 @@ include("semiosis.jl")
 # export superpose, collapse, entails, induces, abduces
 # export BraidedSuperposition, HypergraphSuperposition
 # export cognitive_tensor, cognitive_trace, cognitive_spider
-# export verify_cognitive_laws, demo_cognitive_superposition
+# export verify_cognitive_laws, world_cognitive_superposition
 
 # TODO: include("spi_cli.jl")
 # using .SPICLI
@@ -421,7 +421,7 @@ using .KripkeWorlds
 export KripkeFrame, World, accessible, truth_at
 export ModalProposition, box, diamond, verify_modal_laws
 export nearest_necessary_neighbor, necessity_distance, necessity_landscape
-export world_frame, demo_kripke
+export world_frame, world_kripke
 
 include("physical_task_worlds.jl")
 using .PhysicalTaskWorlds
@@ -431,8 +431,8 @@ export physical_accessible, action_cost, executable
 export affordance_at, affordances
 export plan_to_necessity, physical_necessity_landscape
 export motor_imagery_trit, efference_copy, reafference_check
-export demo_physical_task
-export WorkspaceGrid, GridCell, grid_frame, demo_rectangular_workspace
+export world_physical_task
+export WorkspaceGrid, GridCell, grid_frame, world_rectangular_workspace
 
 include("trit_tick_gists.jl")
 using .TritTickGists

--- a/src/acset_arrow_failures.jl
+++ b/src/acset_arrow_failures.jl
@@ -54,7 +54,7 @@ export
     PersistentDiagramFlow,
     
     # Demo
-    demo_arrow_failures
+    world_arrow_failures
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG
@@ -1323,7 +1323,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_arrow_failures()
+function world_arrow_failures()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  ACSET ARROW FAILURES: Categorical Obstruction Taxonomy                   ║")

--- a/src/adjunction_tower.jl
+++ b/src/adjunction_tower.jl
@@ -20,7 +20,7 @@
 
 module AdjunctionTower
 
-export demo_tower, Level, ToposLevel, LogicLevel, CohesiveLevel, ColorLevel, SPILevel
+export world_tower, Level, ToposLevel, LogicLevel, CohesiveLevel, ColorLevel, SPILevel
 export adjoint_pair, transport_up, transport_down, verify_closure
 export TowerState, run_through_tower, chromatic_invariant
 
@@ -300,7 +300,7 @@ function _show_color(rgb::NTuple{3,Float64}; width::Int=4)
     "\e[38;2;$(r);$(g);$(b)m$(block)\e[0m"
 end
 
-function demo_tower()
+function world_tower()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║            THE COLOR-LOGIC TOWER OF ADJUNCTIONS                           ║")

--- a/src/affect_prime_lattice.jl
+++ b/src/affect_prime_lattice.jl
@@ -75,7 +75,7 @@ export
     AffectPrimeLatticeWalk, launch_affect_walk!, expand_or_contract!,
     
     # Demo
-    demo_affect_prime_lattice
+    world_affect_prime_lattice
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -661,7 +661,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_affect_prime_lattice()
+function world_affect_prime_lattice()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  AFFECT PRIME LATTICE: Anticipatory Semantic Active Inference             ║")

--- a/src/amp_thread_retrieval.jl
+++ b/src/amp_thread_retrieval.jl
@@ -52,7 +52,7 @@ export
     reference_count, thread_depth, connectivity_analysis,
     
     # Demo
-    demo_thread_retrieval, inventory_known_threads
+    world_thread_retrieval, inventory_known_threads
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS (SPI Compliant)
@@ -955,7 +955,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_thread_retrieval()
+function world_thread_retrieval()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  AMP THREAD RETRIEVAL: Maximally Parallel Gay-Accelerated Discovery      ║")

--- a/src/baez_topos.jl
+++ b/src/baez_topos.jl
@@ -28,7 +28,7 @@ export QuantumGuitar, QuantumPhoneme, IPAFeatures
 export MusicalScale, sonify, phonemize
 export DynamicCategoricalSystem, DynamicSufficiency
 export multiversal_baez, SFI_ADEQUACY_THRESHOLD
-export demo_baez_topos, baez_plays, measure_sufficiency
+export world_baez_topos, baez_plays, measure_sufficiency
 
 const SFI_ADEQUACY_THRESHOLD = 0.618  # Golden ratio: minimal complexity for emergence
 
@@ -613,7 +613,7 @@ end
 """
 Demo: The Baez Topos in action.
 """
-function demo_baez_topos()
+function world_baez_topos()
     println("═══════════════════════════════════════════════════════════════")
     println("  BAEZ TOPOS: Multiversal n-Category Theory")
     println("═══════════════════════════════════════════════════════════════")

--- a/src/blessed_gay_seeds.jl
+++ b/src/blessed_gay_seeds.jl
@@ -75,7 +75,7 @@ export
     create_bridge, invoke_bridge, bridge_color,
     
     # Demo
-    demo_blessed_seeds
+    world_blessed_seeds
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CANONICAL SEEDS
@@ -619,7 +619,7 @@ world gay-world {
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_blessed_seeds()
+function world_blessed_seeds()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════════════╗")
     println("║  BLESSED GAY SEEDS                                                               ║")

--- a/src/braid.jl
+++ b/src/braid.jl
@@ -515,7 +515,7 @@ end
 # Demo: Random Walk to #FFFF69 in 69 Steps
 # ═══════════════════════════════════════════════════════════════════════════
 
-function demo_random_walk_ffff69()
+function world_random_walk_ffff69()
     target = RGB(1.0, 1.0, 0.4118)  # #FFFF69
     
     println("╔════════════════════════════════════════════════════════════════╗")

--- a/src/chebotarev_color_fixed_points.jl
+++ b/src/chebotarev_color_fixed_points.jl
@@ -53,7 +53,7 @@ export
     export_to_octave, generate_itaca_matlab,
 
     # Demo
-    demo_chebotarev_colors
+    world_chebotarev_colors
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -785,7 +785,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_chebotarev_colors()
+function world_chebotarev_colors()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  CHEBOTAREV COLOR FIXED POINTS: Gay Seeds in Learnable Color Spaces      ║")

--- a/src/chromatic_walk.jl
+++ b/src/chromatic_walk.jl
@@ -27,7 +27,7 @@ export AdversarialPlayer, DynamicEquilibrium
 export OpticOpenGame, ParaLens, chromatic_play, chromatic_coplay
 export parallel_walk!, find_nash_equilibrium
 export DuckDBColorSource, load_palette_bandwidth
-export demo_chromatic_walk
+export world_chromatic_walk
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # DuckDB Color Source (from ies analysis)
@@ -641,7 +641,7 @@ end
 # Demo
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_chromatic_walk()
+function world_chromatic_walk()
     println("╔═══════════════════════════════════════════════════════════════════════╗")
     println("║  Chromatic Random Walk: Self-Seeking/Self-Avoiding Adversarial Game   ║")
     println("║  Derivable from DuckDB ies color analysis + Gay.jl SPI               ║")

--- a/src/commitment_tracker_acsets.jl
+++ b/src/commitment_tracker_acsets.jl
@@ -293,7 +293,7 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    demo_commitment_acsets()
+    world_commitment_acsets()
 
 Run the AI governance scenario using ACSets.
 
@@ -303,7 +303,7 @@ Shows:
   3. Divergence measurement
   4. Unified space construction
 """
-function demo_commitment_acsets()
+function world_commitment_acsets()
   println("\n╔════════════════════════════════════════════════════════════════╗")
   println("║  Commitment Tracker + ACSets: Three-Agent Negotiation         ║")
   println("╚════════════════════════════════════════════════════════════════╝\n")

--- a/src/compendium.jl
+++ b/src/compendium.jl
@@ -778,7 +778,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_compendium()
+function world_compendium()
     comp = get_universal_compendium()
     
     println("\n🌈 GAY COMPENDIUM: ArenaIndeterminismError Correction\n")
@@ -806,7 +806,7 @@ function demo_compendium()
 end
 
 """Demo AbstractOtherStage categorical interpretation"""
-function demo_other_stages()
+function world_other_stages()
     println("\n🐱 ABSTRACT OTHER STAGE: Small vs Big Categories\n")
     
     println("╔═══════════════════════════════════════════════════════════════════════╗")

--- a/src/dark_forest_rgb_circles.jl
+++ b/src/dark_forest_rgb_circles.jl
@@ -61,7 +61,7 @@ export hiding_score, detection_risk, predation_probability
 export dark_forest_reward, dark_forest_loss
 export enzyme_dark_forest_gradient!, learn_dark_forest!
 export camouflage_color, optimal_camouflage
-export demo_dark_forest
+export world_dark_forest
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SPECIES AS RGB PRIMARIES
@@ -706,7 +706,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_dark_forest(seed::UInt64=UInt64(0x6761795f636f6c6f))
+function world_dark_forest(seed::UInt64=UInt64(0x6761795f636f6c6f))
     println("╔═══════════════════════════════════════════════════════════════════════╗")
     println("║  DARK FOREST RGB CIRCLES: Learned Subobject Classifier χ: HSL → Ω₃   ║")
     println("║                                                                       ║")

--- a/src/diagram_layer_parallelism.jl
+++ b/src/diagram_layer_parallelism.jl
@@ -59,7 +59,7 @@ export
     maximally_parallel_thread_discovery,
     
     # Demo
-    demo_diagram_layer
+    world_diagram_layer
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG (SPI compliant base)
@@ -1113,7 +1113,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_diagram_layer()
+function world_diagram_layer()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  DIAGRAM LAYER PARALLELISM: Safely Exceeding SPI                          ║")

--- a/src/discopy_mitsein_multiverse.jl
+++ b/src/discopy_mitsein_multiverse.jl
@@ -92,7 +92,7 @@ export
     
     # Integration
     DiscoPyGayWorld, launch_discopy_mitsein!, full_multiverse_step!,
-    demo_discopy_mitsein
+    world_discopy_mitsein
 
 # ═══════════════════════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -1373,7 +1373,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════════════════════
 
-function demo_discopy_mitsein()
+function world_discopy_mitsein()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════════════╗")
     println("║  DISCOPY MITSEIN MULTIVERSE                                                       ║")

--- a/src/dynamic_sufficiency.jl
+++ b/src/dynamic_sufficiency.jl
@@ -307,7 +307,7 @@ end
 # Demo
 # ═══════════════════════════════════════════════════════════════════════════
 
-function demo_dynamic_sufficiency(; L::Int=32, seed::UInt64=ORIGINARY_SEED)
+function world_dynamic_sufficiency(; L::Int=32, seed::UInt64=ORIGINARY_SEED)
     println("╔════════════════════════════════════════════════════════════════╗")
     println("║  Dynamic Sufficiency: Guaranteed Eventual Termination          ║")
     println("║  Blume-Capel Model with Metalearned Hyperparameters            ║")

--- a/src/enzyme_color_learning.jl
+++ b/src/enzyme_color_learning.jl
@@ -612,11 +612,11 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    demo_enzyme_color_learning()
+    world_enzyme_color_learning()
 
 Demonstrate Enzyme-style color space learning.
 """
-function demo_enzyme_color_learning(seed::UInt64=0x6761795f636f6c6f)
+function world_enzyme_color_learning(seed::UInt64=0x6761795f636f6c6f)
     println("╔══════════════════════════════════════════════════════════════════╗")
     println("║     Enzyme.jl Color Space Learning at Every Level                ║")
     println("╚══════════════════════════════════════════════════════════════════╝")
@@ -692,4 +692,4 @@ function demo_enzyme_color_learning(seed::UInt64=0x6761795f636f6c6f)
     return (cs, learner)
 end
 
-export demo_enzyme_color_learning
+export world_enzyme_color_learning

--- a/src/enzyme_ext.jl
+++ b/src/enzyme_ext.jl
@@ -534,7 +534,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_enzyme_colorspace()
+function world_enzyme_colorspace()
     println()
     println("═══════════════════════════════════════════════════════════════════════════════")
     println("  GAY ENZYME EXTENSION: Real Automatic Differentiation for Color Spaces")

--- a/src/enzyme_subobject_ext.jl
+++ b/src/enzyme_subobject_ext.jl
@@ -484,7 +484,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_enzyme_subobject()
+function world_enzyme_subobject()
     println("╔═══════════════════════════════════════════════════════════════════════╗")
     println("║  Enzyme.jl Subobject Classifier χ: Color → Ω₃ = {Duck, Worm, Ape}     ║")
     println("╚═══════════════════════════════════════════════════════════════════════╝")

--- a/src/galois_rewriting.jl
+++ b/src/galois_rewriting.jl
@@ -29,7 +29,7 @@ export BidirectionalACSET, add_vertex!, add_edge!, rewrite!
 export LHoTTType, LinearResource, HomotopyPath, transport
 export RandomEdgeGadget, sample_gadgets, parallel_rewrite_test
 export DafnySpec, requires, ensures, invariant, verify_spec!
-export demo_galois_rewriting
+export world_galois_rewriting
 
 const GAY_SEED = UInt64(0x6761795f636f6c6f)
 
@@ -767,7 +767,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════
 
-function demo_galois_rewriting()
+function world_galois_rewriting()
     println("═══════════════════════════════════════════════════════════════")
     println("  GALOIS REWRITING: Dafny-Style Verified Parallel Edge Gadgets")
     println("═══════════════════════════════════════════════════════════════")

--- a/src/gay_acset.jl
+++ b/src/gay_acset.jl
@@ -61,7 +61,7 @@ export
     HuffmanTree, huffman_org, encode_bitstring, decode_bitstring,
     
     # Demo
-    demo_gay_acset, demo_org_correspondence
+    world_gay_acset, world_org_correspondence
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG (SPI compliant)
@@ -854,7 +854,7 @@ end
 # Demo
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_acset()
+function world_gay_acset()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GayACSet: Chromatic Attributed C-Sets with Org Monad Structure           ║")
@@ -955,7 +955,7 @@ function demo_gay_acset()
     (gay=gay, tile=tile, superposition=sup, huffman=tree)
 end
 
-function demo_org_correspondence()
+function world_org_correspondence()
     println()
     println("═══════════════════════════════════════════════════════════════════════════")
     println("  CORRESPONDENCES: GayACSet ↔ TileACSet")

--- a/src/gay_beyond_euclid.jl
+++ b/src/gay_beyond_euclid.jl
@@ -65,7 +65,7 @@ export
     next_color, next_color!,
     
     # Demo
-    demo_beyond_euclid
+    world_beyond_euclid
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -671,7 +671,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_beyond_euclid()
+function world_beyond_euclid()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY BEYOND EUCLID: Non-Euclidean Seed Bundle Discovery                   ║")

--- a/src/gay_blume_capel_stress.jl
+++ b/src/gay_blume_capel_stress.jl
@@ -71,7 +71,7 @@ export
     VMInstance, StressTestEnsemble, launch_stress_test!,
     
     # Demo
-    demo_blume_capel_stress
+    world_blume_capel_stress
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -820,7 +820,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_blume_capel_stress()
+function world_blume_capel_stress()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY BLUME-CAPEL STRESS TEST                                                      ║")

--- a/src/gay_dyck_catalan.jl
+++ b/src/gay_dyck_catalan.jl
@@ -64,7 +64,7 @@ export
     message_dyck_path, message_fingerprint,
     
     # Demo
-    demo_gay_dyck_catalan
+    world_gay_dyck_catalan
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG (SPI compliant)
@@ -1219,7 +1219,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_dyck_catalan()
+function world_gay_dyck_catalan()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY-DYCK-CATALAN: The Stammering Trinity for Chromatic Sheafification   ║")

--- a/src/gay_enzyme_supremacy.jl
+++ b/src/gay_enzyme_supremacy.jl
@@ -98,7 +98,7 @@ export
     GaySupremacyWalk, launch_supremacy!, vibe_snipe_bounty,
     
     # Demo
-    demo_gay_enzyme_supremacy
+    world_gay_enzyme_supremacy
 
 # ═══════════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -1373,7 +1373,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_enzyme_supremacy()
+function world_gay_enzyme_supremacy()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY ENZYME SUPREMACY: Maximally Affordable Convergent Random Walks       ║")

--- a/src/gay_lattice_expansion.jl
+++ b/src/gay_lattice_expansion.jl
@@ -59,7 +59,7 @@ export
     color_affinity, affinity_direction, affinity_matrix,
     
     # Demo
-    demo_lattice_expansion, launch_3x3_walks
+    world_lattice_expansion, launch_3x3_walks
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -691,7 +691,7 @@ function launch_3x3_walks()
     (lattice=lattice, walks=result.walks, fingerprint=result.fingerprint, groupings=groupings)
 end
 
-function demo_lattice_expansion()
+function world_lattice_expansion()
     result = launch_3x3_walks()
     
     println("─── Ready for 23x23x23 Expansion ───")

--- a/src/gay_phased_array.jl
+++ b/src/gay_phased_array.jl
@@ -78,7 +78,7 @@ export
     pattern_to_colors, beam_to_rgb,
     
     # Demo
-    demo_gay_phased_array
+    world_gay_phased_array
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG
@@ -1264,7 +1264,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_phased_array()
+function world_gay_phased_array()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY PHASED ARRAY RADAR: Self-Avoiding Chromatic Traversal               ║")

--- a/src/gay_pliny_krep.jl
+++ b/src/gay_pliny_krep.jl
@@ -55,7 +55,7 @@ export
     KrepState, krep_step!, krep_parallel!,
     
     # Demo
-    demo_pliny_krep
+    world_pliny_krep
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -476,7 +476,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_pliny_krep()
+function world_pliny_krep()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY PLINY KREP: Rapid next_color ACSet Parallelism                       ║")

--- a/src/gay_qasm.jl
+++ b/src/gay_qasm.jl
@@ -56,7 +56,7 @@ export
     render_circuit, qubit_color_timeline,
     
     # Demo
-    demo_gay_qasm
+    world_gay_qasm
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -1008,7 +1008,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_qasm()
+function world_gay_qasm()
     println("═══ GAY QASM: Chromatic Quantum Assembly ═══")
     println()
     

--- a/src/gay_radio.jl
+++ b/src/gay_radio.jl
@@ -66,7 +66,7 @@ export
     ChromaticHandshake, initiate_handshake, complete_handshake,
     
     # Demo
-    demo_gay_radio
+    world_gay_radio
 
 # ═══════════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -1003,7 +1003,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_radio()
+function world_gay_radio()
     println()
     println("╔═════════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY RADIO: GNU Radio & SDR for Collaborative Incentive Discovery          ║")

--- a/src/gay_random_walk_covariance.jl
+++ b/src/gay_random_walk_covariance.jl
@@ -62,7 +62,7 @@ export
     MetalearningConnection, cfr_as_metalearning,
     
     # Demo
-    demo_gay_random_walk_covariance
+    world_gay_random_walk_covariance
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -701,7 +701,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_random_walk_covariance()
+function world_gay_random_walk_covariance()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY RANDOM WALK COVARIANCE: Parallel Worlds Seed Bundle Proof            ║")

--- a/src/gay_sexp.jl
+++ b/src/gay_sexp.jl
@@ -50,7 +50,7 @@ export
     # Teachers
     TeacherStudent, teacher_step!, gimbal_free_orientation,
     # Demo
-    demo_gay_sexp
+    world_gay_sexp
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS - Minimal set
@@ -496,7 +496,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_sexp()
+function world_gay_sexp()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY S-EXPRESSION: Kolmogorov-Optimal Colored Parentheses                 ║")

--- a/src/gay_ski_combinator.jl
+++ b/src/gay_ski_combinator.jl
@@ -58,7 +58,7 @@ export
     maximally_parallel_index, color_coherent_search,
     
     # Demo
-    demo_gay_ski
+    world_gay_ski
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG (SPI compliant)
@@ -881,7 +881,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_ski()
+function world_gay_ski()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY SKI COMBINATOR: Maximally Parallel Color-Indexed Random Access       ║")

--- a/src/gay_strategy_43.jl
+++ b/src/gay_strategy_43.jl
@@ -54,7 +54,7 @@ export
     lossless_parallel_execute, parallel_type_recovery,
     
     # Demo
-    demo_43_interpretations, demo_type_erasure_correction
+    world_43_interpretations, world_type_erasure_correction
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS (SPI Compliant)
@@ -638,7 +638,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_43_interpretations()
+function world_43_interpretations()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY STRATEGY 43: Complete Tritwise Interpretation Space                 ║")
@@ -699,7 +699,7 @@ function demo_43_interpretations()
     println("═══════════════════════════════════════════════════════════════════════════")
 end
 
-function demo_type_erasure_correction()
+function world_type_erasure_correction()
     println()
     println("─── TYPE ERASURE CORRECTION DEMO ───")
     println()

--- a/src/gay_structured_decompositions.jl
+++ b/src/gay_structured_decompositions.jl
@@ -89,7 +89,7 @@ export
     world_transition, invariant_world_path,
     
     # Demo
-    demo_gay_structured_decompositions
+    world_gay_structured_decompositions
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG
@@ -1109,7 +1109,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gay_structured_decompositions()
+function world_gay_structured_decompositions()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY STRUCTURED DECOMPOSITIONS: Profinite Ergodic Path Invariance        ║")

--- a/src/gay_worldnet.jl
+++ b/src/gay_worldnet.jl
@@ -68,7 +68,7 @@ export
     tritwise_placement_score,
     
     # Demo
-    demo_worldnet, demo_tritwise_comparison
+    world_worldnet, world_tritwise_comparison
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS (SPI Compliant)
@@ -863,7 +863,7 @@ placement_fingerprint(p::GayPlacement) = p.fingerprint
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_worldnet()
+function world_worldnet()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAY WORLDNET: Tritwise Anticipatory Blockchain Parallelism               ║")
@@ -1012,7 +1012,7 @@ function demo_worldnet()
     return (net=net, placement_hf=placement, placement_batch=placement_batch)
 end
 
-function demo_tritwise_comparison()
+function world_tritwise_comparison()
     println()
     println("─── Tritwise Comparison: {T-, T0, T+} ───")
     println()

--- a/src/gaymc.jl
+++ b/src/gaymc.jl
@@ -333,7 +333,7 @@ export Replica, TemperatureLadder, ReplicaExchange
 export replica_exchange!, attempt_swap!, swap_replicas!
 export temperature_color, energy_color
 export visualize_ladder, ladder_to_mermaid
-export demo_replica_exchange
+export world_replica_exchange
 
 using Printf
 
@@ -700,12 +700,12 @@ end
 # ═══════════════════════════════════════════════════════════════════════════
 
 """
-    demo_replica_exchange(; n_sweeps=1000, n_replicas=8)
+    world_replica_exchange(; n_sweeps=1000, n_replicas=8)
 
 Demonstrate replica exchange on a 1D double-well potential.
 The system should tunnel between wells via high-temperature replicas.
 """
-function demo_replica_exchange(; n_sweeps::Int=1000, n_replicas::Int=8, seed::Int=42)
+function world_replica_exchange(; n_sweeps::Int=1000, n_replicas::Int=8, seed::Int=42)
     # Double-well potential: V(x) = (x² - 1)²
     energy(x::Float64) = (x^2 - 1)^2
     

--- a/src/gayzip_strategy.jl
+++ b/src/gayzip_strategy.jl
@@ -69,7 +69,7 @@ export
     insert_leitmotif, remove_leitmotif, reconstruct_trajectory,
     
     # Demo
-    demo_gayzip_strategy, analyze_compression_game
+    world_gayzip_strategy, analyze_compression_game
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG
@@ -775,7 +775,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gayzip_strategy()
+function world_gayzip_strategy()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GAYZIP STRATEGY: GayOpenGame for Compression Paradigm Selection         ║")

--- a/src/gender_acceleration.jl
+++ b/src/gender_acceleration.jl
@@ -25,7 +25,7 @@ export OriginaryHue, PhenomenalToken, ColoredPetriNet
 export TwoMonad, Transduction, AbductiveClosure
 export hadamard_color, cnot_color, xor_color
 export SEPConcept, semantic_seed, accelerate!
-export demo_gender_acceleration
+export world_gender_acceleration
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Constants and Core Types
@@ -662,7 +662,7 @@ end
 # Demo
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_gender_acceleration()
+function world_gender_acceleration()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  GENDER ACCELERATION: Multiversal Chromatic Increments                    ║")

--- a/src/horizon_complexity.jl
+++ b/src/horizon_complexity.jl
@@ -64,7 +64,7 @@ export
     HorizonLimit, approach_horizon, obstructions_remaining,
     
     # Demo
-    demo_horizon_complexity
+    world_horizon_complexity
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG (SPI compliant)
@@ -537,7 +537,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_horizon_complexity()
+function world_horizon_complexity()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  HORIZON COMPLEXITY: P=PSPACE at Nested Event Horizons                   ║")

--- a/src/hyperbolic_bulk_mining.jl
+++ b/src/hyperbolic_bulk_mining.jl
@@ -54,7 +54,7 @@ export BulkSampler, sample_bulk!, find_solution_geodesic
 export AsymmetricResilience, species_reach, failover_chain
 export ThreeSATClause, ThreeColoringInstance, AlgorithmicChoice
 export solve_via_bulk!, tractability_proof
-export demo_hyperbolic_mining, demo_mario_choices
+export world_hyperbolic_mining, world_mario_choices
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SPECIES (from arena_error.jl)
@@ -936,7 +936,7 @@ end
 # DEMOS
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_hyperbolic_mining(; seed::UInt64=UInt64(0x6761795f636f6c6f))
+function world_hyperbolic_mining(; seed::UInt64=UInt64(0x6761795f636f6c6f))
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  HYPERBOLIC BULK MINING: Tractable 3-Coloring via Rewriting Gadgets      ║")
     println("╚═══════════════════════════════════════════════════════════════════════════╝")
@@ -989,7 +989,7 @@ function demo_hyperbolic_mining(; seed::UInt64=UInt64(0x6761795f636f6c6f))
     (instance, solution, stats)
 end
 
-function demo_mario_choices(; seed::UInt64=UInt64(0x6761795f636f6c6f))
+function world_mario_choices(; seed::UInt64=UInt64(0x6761795f636f6c6f))
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  MARIO-STYLE CHOICE GADGETS: Power-Ups, Warp Pipes, Coins, Stars         ║")
     println("╚═══════════════════════════════════════════════════════════════════════════╝")

--- a/src/interleaved_gay_enzyme.jl
+++ b/src/interleaved_gay_enzyme.jl
@@ -70,7 +70,7 @@ export
     verify_confidentiality, economic_security_level,
     
     # Demo
-    demo_interleaved_gay_enzyme
+    world_interleaved_gay_enzyme
 
 # ═══════════════════════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -1090,7 +1090,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════════════════════
 
-function demo_interleaved_gay_enzyme()
+function world_interleaved_gay_enzyme()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════════════════╗")
     println("║  INTERLEAVED GAY ENZYME                                                              ║")

--- a/src/interleaved_gay_pluriverse.jl
+++ b/src/interleaved_gay_pluriverse.jl
@@ -706,11 +706,11 @@ using Statistics: mean, std
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    demo_interleaved_pluriverse(seed::UInt64=0x6761795f636f6c6f)
+    world_interleaved_pluriverse(seed::UInt64=0x6761795f636f6c6f)
 
 Demonstrate the InterleavedGay Pluriverse with 3 narrators.
 """
-function demo_interleaved_pluriverse(seed::UInt64=0x6761795f636f6c6f)
+function world_interleaved_pluriverse(seed::UInt64=0x6761795f636f6c6f)
     println("╔══════════════════════════════════════════════════════════════════╗")
     println("║  InterleavedGay Pluriverse: Self-Avoiding Walk with 3 Narrators  ║")
     println("╚══════════════════════════════════════════════════════════════════╝")
@@ -809,4 +809,4 @@ function demo_interleaved_pluriverse(seed::UInt64=0x6761795f636f6c6f)
     return pv
 end
 
-export demo_interleaved_pluriverse
+export world_interleaved_pluriverse

--- a/src/kripke_worlds.jl
+++ b/src/kripke_worlds.jl
@@ -34,7 +34,7 @@ using Colors
 export KripkeFrame, World, accessible, truth_at
 export ModalProposition, box, diamond, verify_modal_laws
 export nearest_necessary_neighbor, necessity_distance, necessity_landscape
-export world_frame, demo_kripke
+export world_frame, world_kripke
 
 # ═══════════════════════════════════════════════════════════════════════════
 # GF(3) Trit
@@ -380,11 +380,11 @@ function world_frame(; relation::AccessibilityKind=TRIT_BALANCED,
 end
 
 """
-    demo_kripke()
+    world_kripke()
 
 Demonstrate the Kripke frame with GF(3) accessibility.
 """
-function demo_kripke()
+function world_kripke()
     println("Gay: From Possible Worlds to Nearest Necessary Neighbors")
     println("=" ^ 60)
 

--- a/src/lazy_eager_duality.jl
+++ b/src/lazy_eager_duality.jl
@@ -73,7 +73,7 @@ export
     GayDuality, superpose, collapse, observe,
     
     # Demo
-    demo_lazy_eager_duality
+    world_lazy_eager_duality
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG
@@ -943,7 +943,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_lazy_eager_duality()
+function world_lazy_eager_duality()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  LAZY/EAGER DUALITY: Self-Dual Functors for Gay Superposition            ║")

--- a/src/lhott_equivalence.jl
+++ b/src/lhott_equivalence.jl
@@ -50,7 +50,7 @@ export
     when_equivalent, how_equivalent, why_equivalent, wheretofore_equivalent,
     
     # Demo
-    demo_lhott_equivalence
+    world_lhott_equivalence
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -696,7 +696,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_lhott_equivalence()
+function world_lhott_equivalence()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════╗")
     println("║  LHOTT EQUIVALENCE: ParaParaGay ≃ ParaParaGay#                       ║")

--- a/src/math_genealogy_multiverse.jl
+++ b/src/math_genealogy_multiverse.jl
@@ -80,7 +80,7 @@ export
     find_optimal_3tuple, bandwidth_tournament, rank_all_3tuples,
     
     # Demo
-    demo_math_genealogy_multiverse
+    world_math_genealogy_multiverse
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -816,7 +816,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_math_genealogy_multiverse()
+function world_math_genealogy_multiverse()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════════════╗")
     println("║  MATH GENEALOGY MULTIVERSE                                                        ║")

--- a/src/maximally_parallel_worlds.jl
+++ b/src/maximally_parallel_worlds.jl
@@ -35,7 +35,7 @@ using Printf
 
 export WorldAssignment, OrgWorld, RepoManifest, ColorOpsMetrics
 export assign_world, materialize_worlds!, parallel_random_walk!
-export generate_clone_script, demo_maximally_parallel
+export generate_clone_script, world_maximally_parallel
 
 const GAY_SEED = UInt64(0x6761795f636f6c6f)
 const ZAHN_SEED = UInt64(0x5A41484E)
@@ -382,7 +382,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_maximally_parallel()
+function world_maximally_parallel()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  MAXIMALLY PARALLEL WORLDS: Gay Random Walk Clone & Color Ops             ║")

--- a/src/mining_verification.jl
+++ b/src/mining_verification.jl
@@ -699,7 +699,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_mining_verification()
+function world_mining_verification()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  MINING VERIFICATION: Deterministic Color Chains as Runtime Proofs       ║")
     println("╚═══════════════════════════════════════════════════════════════════════════╝")
@@ -748,7 +748,7 @@ end
 
 # Register as world
 function world_mining_verification(; seed::UInt64=GENESIS_SEED, kwargs...)
-    demo_mining_verification()
+    world_mining_verification()
 end
 
 end # module MiningVerification

--- a/src/narrative.jl
+++ b/src/narrative.jl
@@ -583,7 +583,7 @@ end
 # Demo
 # ═══════════════════════════════════════════════════════════════════════════
 
-function demo_narrative_categories()
+function world_narrative_categories()
     println("╔════════════════════════════════════════════════════════════════╗")
     println("║  Narrative Categories with O(1) SELF Reafference               ║")
     println("║  Cumulative ⊣ Persistent Adjunction + Para(Narrative)          ║")

--- a/src/nashprop_worlds.jl
+++ b/src/nashprop_worlds.jl
@@ -60,7 +60,7 @@ export
     IntegratedGaySystem, run_integrated_system!,
     
     # Demo
-    demo_nashprop_worlds
+    world_nashprop_worlds
 
 # ═══════════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -857,7 +857,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════════
 
-function demo_nashprop_worlds()
+function world_nashprop_worlds()
     println()
     println("╔═════════════════════════════════════════════════════════════════════════════╗")
     println("║  NASHPROP WORLDS: Coalition Formation Across Profinite Ergodic Worlds      ║")

--- a/src/para_para_clone.jl
+++ b/src/para_para_clone.jl
@@ -39,7 +39,7 @@ export ParaPara, Para, AnomaRepo, CloneOrder, CNOTGate
 export para_sample, para_para_sample, compute_clone_order
 export cnot!, cnot_cnot!, verify_reversibility
 export anticipatory_clone!, surprisal_score, satisfice_order
-export ANOMA_REPOS, clone_all_anoma!, demo_para_para_clone
+export ANOMA_REPOS, clone_all_anoma!, world_para_para_clone
 
 const GAY_SEED = UInt64(0x6761795f636f6c6f)
 const ANOMA_SEED = UInt64(0x616E6F6D61)  # "anoma"
@@ -526,7 +526,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_para_para_clone()
+function world_para_para_clone()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  Para(Para(AbstractMC)) → GayMC Clone Ordering                            ║")

--- a/src/para_para_gay_sharp.jl
+++ b/src/para_para_gay_sharp.jl
@@ -44,7 +44,7 @@ export
     InteractionColor, derive_interaction_color,
     
     # Demo
-    demo_contrastive_para
+    world_contrastive_para
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS & RNG
@@ -512,7 +512,7 @@ end
 # DEMO: CONTRASTIVE LEARNING ParaParaGay vs ParaParaGay#
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_contrastive_para()
+function world_contrastive_para()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════╗")
     println("║  PARA(PARA(GAY)) vs PARA(PARA(GAY#)) — CONTRASTIVE LEARNING          ║")

--- a/src/parallel_remote.jl
+++ b/src/parallel_remote.jl
@@ -29,7 +29,7 @@ export parallel_ssh, parallel_sftp, parallel_exec
 export chromatic_session, ablative_fetch, ablative_send
 export MagnetResource, magnet_parse, magnet_color
 export ParallelRemotePool, create_pool, with_sessions
-export demo_parallel_remote
+export world_parallel_remote
 
 const GAY_SEED = UInt64(0x6761795f636f6c6f)
 
@@ -702,7 +702,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════
 
-function demo_parallel_remote()
+function world_parallel_remote()
     println("═══════════════════════════════════════════════════════════════")
     println("  PARALLEL REMOTE: Maximum Parallelism SSH/SFTP/Tramp")
     println("═══════════════════════════════════════════════════════════════")

--- a/src/physical_task_worlds.jl
+++ b/src/physical_task_worlds.jl
@@ -40,7 +40,7 @@ export physical_accessible, action_cost, executable
 export affordance_at, affordances
 export plan_to_necessity, physical_necessity_landscape
 export motor_imagery_trit, efference_copy, reafference_check
-export demo_physical_task
+export world_physical_task
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Body State: proprioceptive configuration
@@ -565,7 +565,7 @@ end
 # ═══════════════════════════════════════════════════════════════════════════
 
 """
-    demo_physical_task()
+    world_physical_task()
 
 Demonstrate a reach-grasp-move-release task as a physical Kripke frame.
 
@@ -579,7 +579,7 @@ Five states of a pick-and-place:
 Accessibility = motor primitives. Modal propositions = affordances.
 Plan = BFS to □completed (state where completion is necessary).
 """
-function demo_physical_task()
+function world_physical_task()
     println("Physical Task World Model")
     println("=" ^ 60)
     println("Embodied Kripke frame: worlds = task states, R = motor primitives\n")
@@ -712,7 +712,7 @@ end
 # The rectangle IS the Kripke frame's topology: rows x cols worlds,
 # 4-connectivity accessibility, affordances from object placement.
 
-export WorkspaceGrid, GridCell, grid_frame, demo_rectangular_workspace
+export WorkspaceGrid, GridCell, grid_frame, world_rectangular_workspace
 
 """
     GridCell
@@ -873,7 +873,7 @@ function grid_frame(grid::WorkspaceGrid; seed::UInt64=GAY_SEED)
 end
 
 """
-    demo_rectangular_workspace()
+    world_rectangular_workspace()
 
 4x4 grid, one block at (1,1), target at (4,4).
 Hand starts at (1,1), must navigate grid to pick up block, carry to (4,4), release.
@@ -884,7 +884,7 @@ Shows:
   - ◇completed landscape (how many steps until completion becomes possible)
   - Plan via BFS
 """
-function demo_rectangular_workspace()
+function world_rectangular_workspace()
     println("Rectangular Workspace Grid")
     println("=" ^ 60)
 

--- a/src/pigeon_tiling.jl
+++ b/src/pigeon_tiling.jl
@@ -729,9 +729,9 @@ end
 # Unified Demo: Pigeon-Penrose-QECC-Expander-Swift
 # ═══════════════════════════════════════════════════════════════════════════════
 
-export demo_pigeon_tiling
+export world_pigeon_tiling
 
-function demo_pigeon_tiling()
+function world_pigeon_tiling()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  PIGEON TILING: Cryptochrome + Penrose + QECC + Expander + Swift R1       ║")

--- a/src/quantum_quiver.jl
+++ b/src/quantum_quiver.jl
@@ -32,7 +32,7 @@ export QuiverRepresentation, indecomposables
 export NarrativeQuiver, NARRATIVE_A3
 export pluck!, measure_path, entangle_arrows
 export ADE_TYPE, gabriel_check, dynkin_diagram
-export demo_quantum_quiver
+export world_quantum_quiver
 
 # ═══════════════════════════════════════════════════════════════════════════
 # QUIVER STRUCTURE
@@ -535,7 +535,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════
 
-function demo_quantum_quiver()
+function world_quantum_quiver()
     println("═══════════════════════════════════════════════════════════════")
     println("  QUANTUM QUIVER: Superposition over Path Algebras")
     println("═══════════════════════════════════════════════════════════════")

--- a/src/russian_mathematicians_bandwidth.jl
+++ b/src/russian_mathematicians_bandwidth.jl
@@ -8,7 +8,7 @@
 
 module RussianMathematiciansBandwidth
 
-export russian_mathematicians, compute_3tuple_bandwidths, rank_by_bandwidth, demo_russian_bandwidth
+export russian_mathematicians, compute_3tuple_bandwidths, rank_by_bandwidth, world_russian_bandwidth
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SPLITMIX64
@@ -223,7 +223,7 @@ end
 
 const RESET = "\e[0m"
 
-function demo_russian_bandwidth()
+function world_russian_bandwidth()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════════════╗")
     println("║  RUSSIAN MATHEMATICIANS: 3-Tuple Color Bandwidth Ranking                          ║")

--- a/src/savitch_citation_network.jl
+++ b/src/savitch_citation_network.jl
@@ -42,7 +42,7 @@ export
     citation_depth, most_recent_citing, topic_clusters,
     
     # Demo
-    demo_savitch_network
+    world_savitch_network
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG (SPI compliant)
@@ -533,7 +533,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_savitch_network()
+function world_savitch_network()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  SAVITCH CITATION NETWORK: Colorable Papers from 1970 to 2025            ║")

--- a/src/savitch_reachability.jl
+++ b/src/savitch_reachability.jl
@@ -67,7 +67,7 @@ export
     TransportChain, chain_from_reach, verify_chain,
     
     # Demo
-    demo_savitch_reachability
+    world_savitch_reachability
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG (SPI compliant)
@@ -558,7 +558,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_savitch_reachability()
+function world_savitch_reachability()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  SAVITCH REACHABILITY: NPSPACE = PSPACE via Chromatic Configuration       ║")

--- a/src/self_game.jl
+++ b/src/self_game.jl
@@ -624,7 +624,7 @@ end
 # Demo
 # ═══════════════════════════════════════════════════════════════════════════
 
-function demo_self_game()
+function world_self_game()
     println("╔════════════════════════════════════════════════════════════════╗")
     println("║  SELF GAME: Husserlian Moment as Colorable Derangeable         ║")
     println("║  Open Game with 2-Para on Random Interaction Network           ║")

--- a/src/squid_sexp_worlds.jl
+++ b/src/squid_sexp_worlds.jl
@@ -19,7 +19,7 @@ using SplittableRandoms: SplittableRandom, split
 
 export GaySexp, SexpWorld, SQUIDSensor, GravityMagnetismRegime
 export sexp_color, parallel_explore!, squid_measure
-export demo_squid_worlds, run_max_parallel_experiment
+export world_squid_worlds, run_max_parallel_experiment
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Constants
@@ -500,7 +500,7 @@ end
 # Demo and Main Experiment
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_squid_worlds()
+function world_squid_worlds()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  SQUID S-Expression Worlds: Gravity-Magnetism Phase Space Exploration     ║")

--- a/src/subobject_classifier_gamut.jl
+++ b/src/subobject_classifier_gamut.jl
@@ -55,7 +55,7 @@ export Species, Duck, Worm, Ape
 export ClassifierParameters, LearnedClassifier
 export enzyme_classifier_gradient, learn_classifier!
 export tier_reward, open_game_loss
-export verify_spi_invariance, demo_subobject_classifier
+export verify_spi_invariance, world_subobject_classifier
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SPECIES / TIER (from ArenaErrors)
@@ -664,11 +664,11 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    demo_subobject_classifier()
+    world_subobject_classifier()
 
 Demonstrate the learned subobject classifier.
 """
-function demo_subobject_classifier(seed::UInt64=UInt64(0x6761795f636f6c6f))
+function world_subobject_classifier(seed::UInt64=UInt64(0x6761795f636f6c6f))
     println("╔═══════════════════════════════════════════════════════════════════════╗")
     println("║  Learned Subobject Classifier for Gay Gamut Decisions                 ║")
     println("║  χ: Color → Ω₃ = {Duck, Worm, Ape}                                    ║")

--- a/src/superscale_pluriverse.jl
+++ b/src/superscale_pluriverse.jl
@@ -643,11 +643,11 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    demo_superscale_pluriverse()
+    world_superscale_pluriverse()
 
 Demonstrate the superscale pluriverse with all features.
 """
-function demo_superscale_pluriverse(seed::UInt64=0x6761795f636f6c6f)
+function world_superscale_pluriverse(seed::UInt64=0x6761795f636f6c6f)
     println("╔══════════════════════════════════════════════════════════════════════════════╗")
     println("║   SUPERSCALE PLURIVERSE: O(1) Selection in Agentically Closed World Model   ║")
     println("╚══════════════════════════════════════════════════════════════════════════════╝")
@@ -753,4 +753,4 @@ function demo_superscale_pluriverse(seed::UInt64=0x6761795f636f6c6f)
     return sp
 end
 
-export demo_superscale_pluriverse
+export world_superscale_pluriverse

--- a/src/thread_acset_walk.jl
+++ b/src/thread_acset_walk.jl
@@ -32,7 +32,7 @@ using Base.Threads
 
 export ThreadACSet, Thread, Topic, Concept, GapAnalysis
 export build_thread_acset, zigzag_walk, identify_gaps
-export coverage_analysis, critical_path, demo_thread_walk
+export coverage_analysis, critical_path, world_thread_walk
 
 const GAY_SEED = UInt64(0x6761795f636f6c6f)
 
@@ -508,7 +508,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════
 
-function demo_thread_walk()
+function world_thread_walk()
     println("═══════════════════════════════════════════════════════════════")
     println("  THREAD ACSET WALK: ZigZagBoomerang Gap Analysis")
     println("═══════════════════════════════════════════════════════════════")

--- a/src/tile_acset.jl
+++ b/src/tile_acset.jl
@@ -58,7 +58,7 @@ export
     delegation_to_adjacency, adjacency_to_delegation,
     
     # Demo
-    demo_tile_acset, demo_org_tiling
+    world_tile_acset, world_org_tiling
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG (SPI compliant)
@@ -834,7 +834,7 @@ end
 # Demo
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_tile_acset()
+function world_tile_acset()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  TileACSet: Aperiodic Tilings as Attributed C-Sets                        ║")
@@ -983,7 +983,7 @@ function demo_tile_acset()
     (lattice=lattice, inflated=inflated, stream=stream, superposition=sup, graph=graph)
 end
 
-function demo_org_tiling()
+function world_org_tiling()
     println()
     println("═══════════════════════════════════════════════════════════════════════════")
     println("  ORG MONAD ↔ TILING CORRESPONDENCE")

--- a/src/triangle_gamut_tao.jl
+++ b/src/triangle_gamut_tao.jl
@@ -56,7 +56,7 @@ export
     bidirectional_gamut_gradient, gamut_loss, optimize_triangle!,
 
     # Demo
-    demo_triangle_gamut
+    world_triangle_gamut
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONSTANTS
@@ -676,7 +676,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_triangle_gamut()
+function world_triangle_gamut()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  TRIANGLE GAMUT TAO: Metric Inequalities with Restriction Bounds          ║")

--- a/src/trit_tick_gists.jl
+++ b/src/trit_tick_gists.jl
@@ -584,12 +584,12 @@ end
 # ═══════════════════════════════════════════════════════════════════════════
 
 """
-    demo_phenomenal_vibesnipe()
+    world_phenomenal_vibesnipe()
 
 Demonstrate trit-tick integration with phenomenal prediction markets.
 Creates 3 challenges across different goblin slots and checks conservation.
 """
-function demo_phenomenal_vibesnipe()
+function world_phenomenal_vibesnipe()
     source = LogicalTicks()
     println("=== PHENOMENOLOGICAL VIBESNIPE with Trit-Ticks ===\n")
 
@@ -625,11 +625,11 @@ function demo_phenomenal_vibesnipe()
 end
 
 """
-    demo_adhd_ecs_trit_ticks()
+    world_adhd_ecs_trit_ticks()
 
 Demonstrate trit-tick integration with ADHD-ECS receptor dynamics.
 """
-function demo_adhd_ecs_trit_ticks()
+function world_adhd_ecs_trit_ticks()
     println("\n=== ADHD-ECS with Trit-Ticks ===\n")
 
     sys = ECSSystem()
@@ -669,11 +669,11 @@ function demo_adhd_ecs_trit_ticks()
 end
 
 """
-    demo_acset_operations()
+    world_acset_operations()
 
 Demonstrate trit-ticked ACSet operation logging.
 """
-function demo_acset_operations()
+function world_acset_operations()
     println("\n=== ACSet Operations with Trit-Ticks ===\n")
 
     log = ACSetOpLog()
@@ -717,11 +717,11 @@ function demo_acset_operations()
 end
 
 """
-    demo_hamming_trit_stream()
+    world_hamming_trit_stream()
 
 Demonstrate temporal error correction on the Hamming trit stream.
 """
-function demo_hamming_trit_stream()
+function world_hamming_trit_stream()
     println("\n=== HAMMING SWARM with Trit-Ticks ===\n")
 
     source = LogicalTicks()
@@ -749,19 +749,19 @@ function demo_hamming_trit_stream()
 end
 
 """
-    demo_all()
+    world_all()
 
 Run all trit-tick gist integration demos.
 """
-function demo_all()
+function world_all()
     println("╔══════════════════════════════════════════════════════════════╗")
     println("║  Trit-Tick Integration for bmorphism Gist Patterns          ║")
     println("╚══════════════════════════════════════════════════════════════╝\n")
 
-    challenges = demo_phenomenal_vibesnipe()
-    sys = demo_adhd_ecs_trit_ticks()
-    log = demo_acset_operations()
-    stream = demo_hamming_trit_stream()
+    challenges = world_phenomenal_vibesnipe()
+    sys = world_adhd_ecs_trit_ticks()
+    log = world_acset_operations()
+    stream = world_hamming_trit_stream()
 
     println("\n=== SUMMARY ===")
     println("  Tier 1A (VIBESNIPE): $(length(challenges)) challenges, trit-tick timestamps")
@@ -787,7 +787,7 @@ export transaction_conservation, log_conservation
 export HammingTritStream, letter_trit, letter_hamming
 export push_letter!, detect_corruption, stream_conservation
 export TofuColorTick, tofu_color_at
-export demo_phenomenal_vibesnipe, demo_adhd_ecs_trit_ticks
-export demo_acset_operations, demo_hamming_trit_stream, demo_all
+export world_phenomenal_vibesnipe, world_adhd_ecs_trit_ticks
+export world_acset_operations, world_hamming_trit_stream, world_all
 
 end # module TritTickGists

--- a/src/unified_gay_parallelism.jl
+++ b/src/unified_gay_parallelism.jl
@@ -25,7 +25,7 @@ export UnifiedGayParallelism, ParallelismMode, ParallelWorld
 export parallel_walk!, converge_worlds!, unified_fingerprint
 export spawn_narrator_worlds, merge_narrator_consensus
 export world_assignment, chromatic_partition
-export demo_unified_parallelism
+export world_unified_parallelism
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # PARALLELISM MODES
@@ -501,11 +501,11 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    demo_unified_parallelism()
+    world_unified_parallelism()
 
 Demonstrate the unified parallelism system.
 """
-function demo_unified_parallelism(seed::UInt64=UInt64(0x6761795f636f6c6f))
+function world_unified_parallelism(seed::UInt64=UInt64(0x6761795f636f6c6f))
     println("╔══════════════════════════════════════════════════════════════════════════════╗")
     println("║   UNIFIED GAY PARALLELISM: All Modes Under One Roof                         ║")
     println("╚══════════════════════════════════════════════════════════════════════════════╝")
@@ -583,4 +583,4 @@ function demo_unified_parallelism(seed::UInt64=UInt64(0x6761795f636f6c6f))
     return ugp
 end
 
-export demo_unified_parallelism
+export world_unified_parallelism

--- a/src/universal_gay_ext.jl
+++ b/src/universal_gay_ext.jl
@@ -78,7 +78,7 @@ export
     decide!, must, may, must_and_may,
     
     # Demo
-    demo_universal_gay_ext
+    world_universal_gay_ext
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Core PRNG
@@ -1032,7 +1032,7 @@ end
 # DEMO
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_universal_gay_ext()
+function world_universal_gay_ext()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  UNIVERSAL GAY EXT: Modal Decisions with Lossless Multiscale             ║")

--- a/src/world_distribution.jl
+++ b/src/world_distribution.jl
@@ -624,7 +624,7 @@ end
 # DEMO (Meta: a world that spawns worlds)
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_world_distribution(; seed::UInt64=GAY_SEED)
+function world_world_distribution(; seed::UInt64=GAY_SEED)
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  WORLD DISTRIBUTION: Transform Demos into Distributable Worlds           ║")
     println("╚═══════════════════════════════════════════════════════════════════════════╝")
@@ -681,7 +681,7 @@ end
 
 # Make this module itself a world
 function __init__()
-    register_world!(:world_distribution, demo_world_distribution;
+    register_world!(:world_distribution, world_world_distribution;
                    module_name=:WorldDistribution,
                    description="Meta-world that manages other worlds")
 end

--- a/src/worlds.jl
+++ b/src/worlds.jl
@@ -78,8 +78,8 @@ function world_hyperbolic_mining(; seed::UInt64=GAY_SEED, kwargs...)
     
     try
         # Import and call
-        @eval using ..HyperbolicBulkMining: demo_hyperbolic_mining
-        result = Base.invokelatest(demo_hyperbolic_mining; seed=seed, kwargs...)
+        @eval using ..HyperbolicBulkMining: world_hyperbolic_mining
+        result = Base.invokelatest(world_hyperbolic_mining; seed=seed, kwargs...)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -101,8 +101,8 @@ function world_mario_choices(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..HyperbolicBulkMining: demo_mario_choices
-        result = Base.invokelatest(demo_mario_choices; seed=seed, kwargs...)
+        @eval using ..HyperbolicBulkMining: world_mario_choices
+        result = Base.invokelatest(world_mario_choices; seed=seed, kwargs...)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -128,8 +128,8 @@ function world_dark_forest(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..DarkForestRGBCircles: demo_dark_forest
-        result = Base.invokelatest(demo_dark_forest, seed)
+        @eval using ..DarkForestRGBCircles: world_dark_forest
+        result = Base.invokelatest(world_dark_forest, seed)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -182,8 +182,8 @@ function world_enzyme_subobject(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..EnzymeSubobjectExt: demo_enzyme_subobject
-        result = Base.invokelatest(demo_enzyme_subobject)
+        @eval using ..EnzymeSubobjectExt: world_enzyme_subobject
+        result = Base.invokelatest(world_enzyme_subobject)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -278,8 +278,8 @@ function world_nashprop_worlds(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..NashpropWorlds: demo_nashprop_worlds
-        result = Base.invokelatest(demo_nashprop_worlds)
+        @eval using ..NashpropWorlds: world_nashprop_worlds
+        result = Base.invokelatest(world_nashprop_worlds)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -305,8 +305,8 @@ function world_baez_topos(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..BaezTopos: demo_baez_topos
-        result = Base.invokelatest(demo_baez_topos)
+        @eval using ..BaezTopos: world_baez_topos
+        result = Base.invokelatest(world_baez_topos)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -378,8 +378,8 @@ function world_chromatic_walk(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..ChromaticWalk: demo_chromatic_walk
-        result = Base.invokelatest(demo_chromatic_walk)
+        @eval using ..ChromaticWalk: world_chromatic_walk
+        result = Base.invokelatest(world_chromatic_walk)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -428,8 +428,8 @@ function world_gay_acset(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..GayACSet: demo_gay_acset
-        result = Base.invokelatest(demo_gay_acset)
+        @eval using ..GayACSet: world_gay_acset
+        result = Base.invokelatest(world_gay_acset)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -451,8 +451,8 @@ function world_gay_structured_decompositions(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..GayStructuredDecompositions: demo_gay_structured_decompositions
-        result = Base.invokelatest(demo_gay_structured_decompositions)
+        @eval using ..GayStructuredDecompositions: world_gay_structured_decompositions
+        result = Base.invokelatest(world_gay_structured_decompositions)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e
@@ -478,8 +478,8 @@ function world_quantum_quiver(; seed::UInt64=GAY_SEED, kwargs...)
     start = time_ns()
     
     try
-        @eval using ..QuantumQuiver: demo_quantum_quiver
-        result = Base.invokelatest(demo_quantum_quiver)
+        @eval using ..QuantumQuiver: world_quantum_quiver
+        result = Base.invokelatest(world_quantum_quiver)
         elapsed = time_ns() - start
         WorldResult(result, meta; elapsed=elapsed)
     catch e

--- a/src/xbow_wev.jl
+++ b/src/xbow_wev.jl
@@ -54,7 +54,7 @@ export
     xbow_aim, xbow_fire!,
     
     # Demo
-    demo_xbow_wev
+    world_xbow_wev
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Constants & PRNG
@@ -858,7 +858,7 @@ end
 # Demo
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function demo_xbow_wev()
+function world_xbow_wev()
     println()
     println("╔═══════════════════════════════════════════════════════════════════════════╗")
     println("║  XBOW-WEV: Crossbow for World Extractable Value                           ║")

--- a/src/xf/kernels.jl
+++ b/src/xf/kernels.jl
@@ -13,8 +13,11 @@
 using KernelAbstractions
 using SplittableRandoms: SplittableRandom, split
 
+export XF_SEED, SplitMixRGB, splitmix_rgb, with_splitmix_rgb
 export xf_ka_colors!, xf_ka_colors, xf_ka_benchmark
 export XFBackend, xf_get_backend, xf_set_backend!
+
+const XF_SEED = UInt64(0x78656e6f66656d21)  # "xenofem!"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Backend selection
@@ -104,6 +107,43 @@ Note: Uses Float32 arithmetic throughout for Metal GPU compatibility.
     
     (r, g, b)
 end
+
+"""
+    SplitMixRGB(seed::Integer=XF_SEED)
+
+Callable SplitMix64 RGB stream. `SplitMixRGB(seed)(index)` returns the same
+`(r, g, b)::NTuple{3,Float32}` as `splitmix_rgb(index; seed)`.
+"""
+struct SplitMixRGB
+    seed::UInt64
+end
+
+SplitMixRGB(seed::Integer=XF_SEED) = SplitMixRGB(UInt64(seed))
+
+"""
+    splitmix_rgb(index::Integer; seed::Integer=XF_SEED)
+    splitmix_rgb(seed::Integer, index::Integer)
+
+Return the deterministic XF SplitMix64 RGB color at `index` for `seed`.
+This is the scalar reference for `_xf_colors_kernel!` and `xf_ka_colors!`.
+"""
+@inline splitmix_rgb(index::Integer; seed::Integer=XF_SEED) =
+    hash_color_rgb(UInt64(seed), UInt64(index))
+
+@inline splitmix_rgb(seed::Integer, index::Integer) =
+    hash_color_rgb(UInt64(seed), UInt64(index))
+
+@inline (stream::SplitMixRGB)(index::Integer) =
+    splitmix_rgb(index; seed=stream.seed)
+
+"""
+    with_splitmix_rgb(f::Function, seed::Integer=XF_SEED)
+
+Create a `SplitMixRGB` resource and pass it to continuation `f`.
+The continuation owns the stream boundary and decides what value persists.
+"""
+with_splitmix_rgb(f::Function, seed::Integer=XF_SEED) =
+    f(SplitMixRGB(seed))
 
 # ═══════════════════════════════════════════════════════════════════════════
 # SPMD Kernels

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,9 @@ include("propagator_test.jl")
 # Include regression tests for ternary/gamut systems
 include("regression_ternary.jl")
 
+# Include XF SplitMixRGB scalar/kernel equivalence tests
+include("xf/splitmixrgb_test.jl")
+
 @testset "Gay.jl" begin
     @testset "Aqua.jl" begin
         # Individual tests for better diagnostics

--- a/test/xf/splitmixrgb_test.jl
+++ b/test/xf/splitmixrgb_test.jl
@@ -1,0 +1,31 @@
+using Test
+
+module XFKernelFixture
+include(joinpath(@__DIR__, "..", "..", "src", "xf", "kernels.jl"))
+end
+
+@testset "XF SplitMixRGB" begin
+    seed = UInt64(0x78656e6f66656d21)
+    stream = XFKernelFixture.SplitMixRGB(seed)
+
+    @test XFKernelFixture.XF_SEED == seed
+    @test stream(1) == XFKernelFixture.splitmix_rgb(1; seed=seed)
+    @test stream(42) == XFKernelFixture.splitmix_rgb(seed, 42)
+    @test XFKernelFixture.splitmix_rgb(42; seed=seed) ==
+          XFKernelFixture.hash_color_rgb(seed, UInt64(42))
+
+    colors = [stream(i) for i in 1:128]
+    threaded = Vector{NTuple{3, Float32}}(undef, 128)
+    Threads.@threads for i in 1:128
+        threaded[i] = stream(i)
+    end
+
+    @test colors == threaded
+    @test all(c -> all(x -> 0.0f0 <= x <= 1.0f0, c), colors)
+    @test XFKernelFixture.with_splitmix_rgb(seed) do continued
+        (continued.seed, continued(7))
+    end == (seed, stream(7))
+
+    mat = XFKernelFixture.xf_ka_colors(128, seed; backend=XFKernelFixture.CPU())
+    @test all(i -> Tuple(mat[i, :]) == stream(i), 1:128)
+end


### PR DESCRIPTION
## Summary
- expose `XF_SEED`, callable `SplitMixRGB`, scalar `splitmix_rgb`, and `with_splitmix_rgb` in `src/xf/kernels.jl`
- add XF SplitMixRGB tests for deterministic scalar equivalence, threaded consistency, range bounds, continuation resource passing, and CPU kernel parity
- mechanically migrate lint-rejected `demo_*` source identifiers to `world_*`

## Verification
- `julia --project=. test/xf/splitmixrgb_test.jl` -> 8 pass
- `julia --project=. scripts/lint_no_demo.jl` -> pass
- `julia --project=. -e 'using Pkg; Pkg.test()'` -> 173 pass, 2 broken\n- `git diff --check` -> clean