### PR TITLE
feat: integrate GayLearnableColor, GayIdentifiers, and add missing O(1) seed/color utility kernels

### DIFF
--- a/GayIdentifiers.jl/Project.toml
+++ b/GayIdentifiers.jl/Project.toml
@@ -1,0 +1,20 @@
+name = "GayIdentifiers"
+uuid = "6a71de00-1069-4dd1-8b44-000000000069"
+authors = ["Physeter Macrocephalus <physeter@plurigrid.com>"]
+version = "0.1.0"
+
+[deps]
+Gay = "f3dee6b2-1ce2-4cc9-bfb1-25e98f6f315b"
+
+[sources]
+Gay = {path = ".."}
+
+[compat]
+Gay = "0.1"
+julia = "1.10"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/GayIdentifiers.jl/README.md
+++ b/GayIdentifiers.jl/README.md
@@ -1,0 +1,40 @@
+# GayIdentifiers.jl
+
+The Gay-flavoured member of tecosaur's `*Identifiers.jl` family
+(`AcademicIdentifiers.jl` / `BioIdentifiers.jl` / `FastIdentifiers.jl`). It parses
+and normalises an identifier, then attaches the **Gay layer**: a deterministic
+colour + GF(3) trit drawn from `Gay.jl`'s `mix64` kernel.
+
+## API (tecosaur idiom + Gay layer)
+```julia
+using GayIdentifiers
+d = parse(GayID, "https://doi.org/10.1371/journal.pone.0068810")
+idkind(d)     # :doi
+shortcode(d)  # "10.1371/journal.pone.0068810"   (canonical)
+purl(d)       # "https://doi.org/10.1371/journal.pone.0068810"
+gaycolor(d)   # "#RRGGBB"   ← Gay.jl hash_color_hex(stable_seed(shortcode), 0)
+gaytrit(d)    # Int8 ∈ {-1,0,1}
+```
+Equivalent inputs canonicalise to the same shortcode ⇒ the **same colour**
+(`doi:…` ≡ `https://doi.org/…`); distinct identifiers ⇒ distinct colours.
+
+## Recognised kinds
+Academic (mirroring AcademicIdentifiers.jl): **doi, orcid, arxiv** — plus this
+project's own schemes: **world:// , vm:// , morphism://** and bare **handle**
+(Beeper/Signal-style). Unknown input → `:unknown` (still coloured).
+
+## GF(3) identity audit (the world://groupoid Σ)
+```julia
+gay_audit(["world://securities","world://groupoid","world://morphism"])
+# (; n=3, sigma, balanced, colors=Dict(shortcode => "#RRGGBB"))
+```
+`sigma = Σ gaytrit mod 3` over a set of identifiers — the scalar of the cross-
+identifier identity groupoid (`world://groupoid`). Σ≡0 = balanced identity set.
+
+## Dependency
+Depends on **`Gay.jl`** by path (`[sources] Gay = {path = "../Gay.jl"}`), so the
+colouring kernel is byte-identical to `world://securities` / `world://morphism`
+(`hash_color_hex(1069,0) == #B35D38`). Lineage: tecosaur's identifier family ×
+our Gay colour kernel × the GF(3) groupoid audit.
+
+Test: `julia --project=. -e 'using Pkg; Pkg.test()'` — 17 assertions GREEN.

--- a/GayIdentifiers.jl/src/GayIdentifiers.jl
+++ b/GayIdentifiers.jl/src/GayIdentifiers.jl
@@ -1,0 +1,67 @@
+module GayIdentifiers
+
+# GayIdentifiers.jl — the Gay-flavoured member of tecosaur's *Identifiers.jl family.
+# Parse/normalise an identifier (academic: DOI/ORCID/arXiv … + our schemes:
+# world:// vm:// morphism:// handle), then attach the Gay layer: a deterministic
+# colour + GF(3) trit from Gay.jl's mix64 kernel. A set of identifiers carries a
+# GF(3) identity audit (the world://groupoid Σ).
+
+using Gay: hash_color_hex, trit, stable_seed
+
+export GayID, idkind, shortcode, purl, gaycolor, gaytrit, gay_audit
+
+abstract type AbstractGayIdentifier end
+
+struct GayID <: AbstractGayIdentifier
+    raw::String
+    kind::Symbol
+    shortcode::String
+end
+
+# (kind, regex with one capture, canonicaliser, purl-prefix) — tecosaur-idiom
+const RECOGNIZERS = Tuple{Symbol,Regex,Function,String}[
+    (:doi,      r"(?:doi:|https?://doi\.org/)?(10\.\d{4,9}/\S+)"i, lowercase, "https://doi.org/"),
+    (:orcid,    r"(?:https?://orcid\.org/)?(\d{4}-\d{4}-\d{4}-\d{3}[\dX])"i, uppercase, "https://orcid.org/"),
+    (:arxiv,    r"(?:arxiv:)?(\d{4}\.\d{4,5}(?:v\d+)?)"i, identity, "https://arxiv.org/abs/"),
+    (:world,    r"^world://(\S+)$", identity, "world://"),
+    (:vm,       r"^vm://(\S+)$",    identity, "vm://"),
+    (:morphism, r"^morphism://(\S+)$", identity, "morphism://"),
+    (:handle,   r"^(@?[A-Za-z][\w.\-]+|\+\d{6,})$", identity, ""),
+]
+
+function Base.parse(::Type{GayID}, s::AbstractString)
+    for (kind, re, canon, _) in RECOGNIZERS
+        m = match(re, s)
+        if m !== nothing
+            cap = (length(m.captures) >= 1 && m.captures[1] !== nothing) ? m.captures[1] : m.match
+            return GayID(String(s), kind, String(canon(cap)))
+        end
+    end
+    GayID(String(s), :unknown, String(s))
+end
+Base.tryparse(::Type{GayID}, s::AbstractString) = parse(GayID, s)
+
+idkind(g::GayID) = g.kind
+shortcode(g::GayID) = g.shortcode
+Base.string(g::GayID) = g.shortcode
+function purl(g::GayID)
+    for (kind, _, _, pre) in RECOGNIZERS
+        kind == g.kind && return string(pre, g.shortcode)
+    end
+    g.shortcode
+end
+
+# --- the Gay layer: deterministic colour + GF(3) trit (Gay.jl mix64 kernel) -----
+_gayseed(g::GayID) = stable_seed(g.shortcode)
+gaycolor(g::GayID) = hash_color_hex(_gayseed(g), 0)
+gaytrit(g::GayID)  = trit(0; seed = _gayseed(g))
+
+# --- GF(3) identity audit over a set of identifiers (world://groupoid Σ) ---------
+function gay_audit(ids)
+    gs = [parse(GayID, x) for x in ids]
+    s = mod(sum(Int(gaytrit(g)) for g in gs), 3)
+    (; n = length(gs), sigma = s, balanced = (s == 0),
+       colors = Dict(shortcode(g) => gaycolor(g) for g in gs))
+end
+
+end # module GayIdentifiers

--- a/GayIdentifiers.jl/test/runtests.jl
+++ b/GayIdentifiers.jl/test/runtests.jl
@@ -1,0 +1,37 @@
+using Test
+using GayIdentifiers
+
+@testset "GayIdentifiers — parse + Gay layer" begin
+    d = parse(GayID, "https://doi.org/10.1371/journal.pone.0068810")
+    @test idkind(d) == :doi
+    @test shortcode(d) == "10.1371/journal.pone.0068810"
+    @test startswith(purl(d), "https://doi.org/")
+    @test occursin(r"^#[0-9A-F]{6}$", gaycolor(d))
+    @test gaytrit(d) in Int8(-1):Int8(1)
+
+    o = parse(GayID, "0000-0002-1825-0097")
+    @test idkind(o) == :orcid
+    @test shortcode(o) == "0000-0002-1825-0097"
+
+    a = parse(GayID, "arXiv:2507.08892")
+    @test idkind(a) == :arxiv
+    @test startswith(purl(a), "https://arxiv.org/abs/")
+
+    w = parse(GayID, "world://securities")
+    @test idkind(w) == :world && shortcode(w) == "securities"
+    v = parse(GayID, "vm://sierpinski/012")
+    @test idkind(v) == :vm
+
+    # canonicalisation ⇒ same colour from equivalent inputs
+    @test gaycolor(d) == gaycolor(parse(GayID, "doi:10.1371/journal.pone.0068810"))
+    # distinct identifiers ⇒ distinct colours
+    @test gaycolor(w) != gaycolor(v)
+end
+
+@testset "GF(3) identity audit (world://groupoid Σ)" begin
+    a = gay_audit(["world://securities", "world://groupoid", "world://morphism"])
+    @test a.n == 3
+    @test a.sigma in 0:2
+    @test length(a.colors) == 3
+    @test all(c -> occursin(r"^#[0-9A-F]{6}$", c), values(a.colors))
+end

--- a/GayLearnableColor.jl/Project.toml
+++ b/GayLearnableColor.jl/Project.toml
@@ -1,0 +1,20 @@
+name = "GayLearnableColor"
+uuid = "7a71c010-1069-4c01-8b44-00000000c101"
+authors = ["Physeter Macrocephalus <physeter@plurigrid.com>"]
+version = "0.1.0"
+
+[deps]
+Gay = "f3dee6b2-1ce2-4cc9-bfb1-25e98f6f315b"
+
+[sources]
+Gay = {path = ".."}
+
+[compat]
+Gay = "0.1"
+julia = "1.10"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/GayLearnableColor.jl/README.md
+++ b/GayLearnableColor.jl/README.md
@@ -1,0 +1,37 @@
+# GayLearnableColor.jl
+
+A **jointly-learnable color space**, *as in Gay.jl colorings*: learn a color
+embedding φ_θ : behaviour → Okhsl color, co-optimised **jointly** over all
+behaviours coupled by their structural distance (MDS into a d-dim color space).
+The learned coordinates **are** the behaviour embedding ⇒ behaviour and color are
+one. Colors are emitted through `Gay.jl`'s own `okhsl_to_rgb`.
+
+## API
+```julia
+using GayLearnableColor
+D  = behaviors_gf3(24)                     # GF(3) 9-trit behaviours → Hamming matrix
+lc = learn_colorspace(D; d=3, iters=500)   # → LearnedColorSpace(X, hexes, corr)
+lc.corr                                     # structure preservation (Pearson)
+lc.hexes                                     # n Okhsl colors via Gay.jl
+graph_distance(adj, n)                       # shortest-path distances of a dyn. graph
+```
+
+## Result (`julia --project=. -e 'using Pkg; Pkg.test()'`, 8 assertions GREEN)
+- 3-D Okhsl color space: morphisms corr **>0.6**, graph **>0.85**.
+- **Color spaces matter**: 3-D beats 1-D hue (`lm.corr > l1.corr`) — 1-D hue is
+  lossy for high-dim behaviour.
+- Colors come from `Gay.jl` (`Gay.okhsl_to_rgb`); cross-substrate canon
+  `hash_color_hex(GAY_SEED,0) == "#B35D38"` checked in-test.
+- Deterministic (Gay `stable_seed`, not process-seeded `hash`).
+
+## Design notes
+- **Depends on `Gay.jl` by path** (`[sources] Gay = {path="../Gay.jl"}`), Julia 1.11+.
+- Uses **analytic MDS gradients** — exact, so no AD library is required. Enzyme
+  (bob's `GayEnzymeExt` LearnableOkhsl backend) would be the faithful AD swap but
+  is numerically redundant here; the gradient of the stress is closed-form.
+- bb concept twin: `~/worlds/scratch/gay-learnable-color/` (`world://gay-learnable-color`).
+- Non-Riemannian scale extension notes live in
+  [`docs/non_riemannian_color_scales.md`](docs/non_riemannian_color_scales.md).
+
+Lineage: bob's learnable-Okhsl (Gay.jl) × jointly-learned structure-coloring ×
+the same `mix64` palette as `world://securities`/`morphism`.

--- a/GayLearnableColor.jl/docs/non_riemannian_color_scales.md
+++ b/GayLearnableColor.jl/docs/non_riemannian_color_scales.md
@@ -1,0 +1,356 @@
+# Non-Riemannian Color Scales
+
+This is a mini-reference for extending `GayLearnableColor.jl` beyond one
+Riemannian-looking perceptual embedding. The common shape is:
+
+```text
+source -> structural scale -> learnable embedding -> perceptual renderer -> check
+```
+
+A color scale here is not just a coordinate system. It is a directed relation
+among stimulus, observer, machine model, rendering substrate, task, and context.
+Each scale below includes an explicit `white-link`. In this document, `white`
+means the neutral/illuminant/context anchor of that scale, not a value judgment.
+
+```text
+white-link: <scale> -> white-anchor
+```
+
+The white anchor may be D65, display white, paper white, background white, an
+adapted neutral point, a maximum-entropy state, or a task-defined "no signal"
+state. The rule: every scale that refers to color must say how it points back
+to its neutral reference.
+
+## Scale Protocol
+
+```julia
+abstract type AbstractColorScale end
+abstract type AbstractWhiteAnchor end
+
+source(scale)       # what generates samples or comparisons
+carrier(scale)      # points, graph nodes, distributions, programs, actions
+compare(scale, a,b) # distance, divergence, order, triplet, loss, or relation
+render(scale, x)    # human/machine visible color or artifact
+white_anchor(scale) # directed neutral reference
+diagnose(scale)     # stress, corr, confusion, task loss, accessibility, etc.
+```
+
+## Twenty-Three Priority Classes
+
+### 1. Diminishing-Return Color
+
+- Core: large perceived differences are not sums of small just-noticeable steps.
+- Scale extension: replace additive path length with a concave difference
+  function, e.g. `D_large = f(D_local)` where `f` is subadditive.
+- Learnable handle: fit `f` from human comparisons or machine discrimination
+  curves.
+- Counterfactual: if this scale is true, optimizing many tiny `Delta E` steps
+  will overstate large palette separations.
+- white-link: `diminishing_return_scale -> neutral_axis_white`.
+
+### 2. Finsler / Hilbert Convex Color
+
+- Core: local cost depends on direction, not only location.
+- Scale extension: represent an observer gamut as a convex body; distance uses
+  directional boundary intersections.
+- Learnable handle: learn the convex reachable region for one observer, display,
+  or model.
+- Counterfactual: moving toward glare white and moving away from it can have
+  different perceptual costs.
+- white-link: `finsler_hilbert_scale -> convex_body_white_boundary`.
+
+### 3. Quasi-Metric Adaptation Color
+
+- Core: `compare(a,b) != compare(b,a)` because adaptation and memory create
+  directed perception.
+- Scale extension: store directed edges or asymmetric matrices.
+- Learnable handle: learn from ordered before/after judgments, not unordered
+  pairs.
+- Counterfactual: a color may be easy to enter from neutral but hard to leave
+  after saturation fatigue.
+- white-link: `quasi_metric_scale -> adaptation_baseline_white`.
+
+### 4. Categorical-Information Color
+
+- Core: color is a distribution over names, labels, or concepts.
+- Scale extension: compare colors by divergence between name distributions.
+- Learnable handle: collect labels or infer names from logs, captions, or UI
+  behavior.
+- Counterfactual: two colors far in Lab may be near if both are called "blue."
+- white-link: `categorical_information_scale -> unnamed_or_neutral_white`.
+
+### 5. Perceptual-Kernel Color
+
+- Core: a reusable distance matrix is learned from aggregate human judgments.
+- Scale extension: store a kernel over a finite palette rather than a formula
+  over all RGB.
+- Learnable handle: triplet matching, pair ratings, spatial arrangement, or
+  model-generated comparisons.
+- Counterfactual: the best scale for a ten-color UI palette may be a table, not
+  a manifold.
+- white-link: `perceptual_kernel_scale -> kernel_white_chip`.
+
+### 6. Triplet / Ordinal Color
+
+- Core: primitive data are statements like "A is closer to B than C."
+- Scale extension: no absolute distances are required; only inequalities.
+- Learnable handle: non-metric MDS, stochastic triplet embedding, ordinal loss.
+- Counterfactual: if users cannot give stable numbers, they may still give
+  stable relative judgments.
+- white-link: `triplet_ordinal_scale -> reference_triplet_white`.
+
+### 7. Graph Color
+
+- Core: colors are nodes; edges are confusions, transitions, or allowed moves.
+- Scale extension: shortest paths, cuts, centrality, and graph embeddings replace
+  Euclidean distance.
+- Learnable handle: build edges from co-occurrence, confusion, adjacency, or
+  UI transitions.
+- Counterfactual: two colors are close because users repeatedly substitute them,
+  even if their coordinates disagree.
+- white-link: `graph_color_scale -> neutral_node_white`.
+
+### 8. Hypergraph / Simplicial Color
+
+- Core: color relations can be irreducibly higher-order: palettes, triples,
+  backgrounds, and scenes.
+- Scale extension: use hyperedges or simplices for "these colors together mean
+  this."
+- Learnable handle: optimize palette-level loss, not pairwise distances only.
+- Counterfactual: a color harmless in pairs may fail inside a five-color legend.
+- white-link: `simplicial_color_scale -> scene_white_simplex`.
+
+### 9. Topological / Persistent Color
+
+- Core: connected components, holes, and persistence across thresholds matter
+  more than individual distances.
+- Scale extension: compute persistence over perceptual or structural color
+  distances.
+- Learnable handle: tune the renderer so topology of behavior survives in color.
+- Counterfactual: a scale is good when clusters survive threshold changes, even
+  if exact distances drift.
+- white-link: `persistent_color_scale -> filtration_white_vertex`.
+
+### 10. Sheaf / Context-Gluing Color
+
+- Core: local color judgments live in contexts and must be glued, or their
+  failure to glue must be recorded.
+- Scale extension: contexts are charts; restriction maps move color meaning
+  between display, print, lighting, and task.
+- Learnable handle: learn compatibility maps and diagnose cocycle drift.
+- Counterfactual: disagreement across contexts is structure, not merely error.
+- white-link: `sheaf_color_scale -> local_white_section`.
+
+### 11. Fiber / Metameric Color
+
+- Core: many physical spectra or render programs map to one perceived color.
+- Scale extension: base space is perceived color; fibers are spectra, devices,
+  pigments, or renderer states.
+- Learnable handle: learn fiber choices that preserve perception while optimizing
+  energy, accessibility, or printability.
+- Counterfactual: two renderings are identical in perception but distinct in
+  machine sensing.
+- white-link: `metameric_fiber_scale -> fiber_white_section`.
+
+### 12. Bayesian / Constancy Color
+
+- Core: perceived color is posterior inference over surface, light, and context.
+- Scale extension: distance lives between posteriors, not raw samples.
+- Learnable handle: infer illuminant and adaptation state jointly with color.
+- Counterfactual: the same RGB patch has different color under different scene
+  hypotheses.
+- white-link: `bayesian_constancy_scale -> inferred_illuminant_white`.
+
+### 13. Causal / Counterfactual Color
+
+- Core: colors are close when interventions on them have similar effects.
+- Scale extension: compare `do(color=x)` outcomes under task, perception, and
+  renderer.
+- Learnable handle: A/B tests, synthetic interventions, or differentiable
+  counterfactual rendering.
+- Counterfactual: if changing hue does not change action, the action-scale
+  distance may be zero.
+- white-link: `causal_color_scale -> no_intervention_white`.
+
+### 14. Task-Loss / Affordance Color
+
+- Core: color distance is whatever changes the success of an action.
+- Scale extension: define scale by loss surfaces for search, warning, selection,
+  grouping, or recall.
+- Learnable handle: optimize colors end-to-end against task performance.
+- Counterfactual: a less uniform palette can be better if it reduces the actual
+  task loss.
+- white-link: `task_loss_scale -> task_background_white`.
+
+### 15. Palette-Native Finite Color
+
+- Core: a palette is a finite object with internal relations; it is not a sample
+  from an infinite continuum.
+- Scale extension: optimize set geometry, order, minimum separation, and
+  stability under extension.
+- Learnable handle: farthest insertion, simulated annealing, graph matching, or
+  learned palette embeddings.
+- Counterfactual: adding one color may require preserving previous assignments.
+- white-link: `palette_native_scale -> palette_background_white`.
+
+### 16. Graph-Matching Color Assignment
+
+- Core: data adjacency should map to perceptual separability.
+- Scale extension: build a data graph and a color-difference graph; align them.
+- Learnable handle: optimize permutations or differentiable relaxations.
+- Counterfactual: the same palette can become better by reassigning colors.
+- white-link: `graph_matching_scale -> graph_canvas_white`.
+
+### 17. Contrastive / Adversarial Machine Color
+
+- Core: color is shaped by positive/negative pairs and by model weaknesses.
+- Scale extension: contrastive distance, triplet loss, adversarial discrepancy.
+- Learnable handle: compare human-near/machine-far and machine-near/human-far
+  cases explicitly.
+- Counterfactual: a color pair can be perceptually identical to humans but
+  separable to a classifier.
+- white-link: `contrastive_machine_scale -> model_input_white`.
+
+### 18. Differentiable-Rendering Color
+
+- Core: color parameters are learned through losses on rendered artifacts.
+- Scale extension: renderer is inside the optimization loop.
+- Learnable handle: backpropagate perceptual, task, or image losses to color
+  coordinates.
+- Counterfactual: the color is the gradient behavior, not only the final RGB.
+- white-link: `differentiable_render_scale -> render_target_white`.
+
+### 19. Generative Latent Color
+
+- Core: color is a latent code decoded by a learned renderer or appearance model.
+- Scale extension: compare latent directions by rendered perceptual effect.
+- Learnable handle: autoencoders, neural appearance models, learned texture
+  codes, or memory tokens.
+- Counterfactual: two latent points are near if their decoded scenes behave
+  similarly under perception.
+- white-link: `generative_latent_scale -> latent_white_code`.
+
+### 20. Accessibility / Multi-Observer Color
+
+- Core: no single observer owns the scale.
+- Scale extension: aggregate or stratify metrics across color-vision types,
+  machines, displays, and lighting.
+- Learnable handle: multi-objective optimization with per-observer constraints.
+- Counterfactual: a palette that is optimal for one observer family may be
+  invalid for another.
+- white-link: `multi_observer_scale -> shared_accessible_white`.
+
+### 21. Temporal / Dynamical Color
+
+- Core: color is a trajectory, rhythm, fade, adaptation curve, or attractor.
+- Scale extension: compare paths and state transitions rather than static points.
+- Learnable handle: recurrent models, dynamical systems, hysteresis tests,
+  temporal contrast.
+- Counterfactual: a blinking color can be a different color experience than its
+  static average.
+- white-link: `temporal_dynamic_scale -> temporal_reset_white`.
+
+### 22. Program-Semantic / Type-Theoretic Color
+
+- Core: color is the denotation of a rendering program or a typed UI role.
+- Scale extension: compare programs by observational equivalence and type-level
+  guarantees.
+- Learnable handle: infer role types from usage, then render role-consistent
+  colors.
+- Counterfactual: `warning-red` and `brand-red` can be different colors even if
+  they share RGB.
+- white-link: `program_semantic_scale -> type_default_white`.
+
+### 23. Human-Rendering / Material-Practice Color
+
+- Core: human rendering is embodied production: brush, pigment, surface, memory,
+  gesture, and correction.
+- Scale extension: distance includes effort, reproducibility, material mixing,
+  and communicability.
+- Learnable handle: learn from sketches, edits, brush histories, print proofs,
+  and repair actions.
+- Counterfactual: two digital colors may be distant if one cannot be rendered by
+  the available material practice.
+- white-link: `human_rendering_scale -> substrate_white`.
+
+## Directional Link Graph
+
+Every priority scale has a directional link to a white anchor. A renderer can
+materialize these as white edges in a visual graph.
+
+```dot
+digraph NonRiemannianColorScales {
+  rankdir=LR;
+  node [shape=box, style="rounded"];
+  edge [color=white, fontcolor=white, label="white-link"];
+
+  diminishing_return_scale -> neutral_axis_white;
+  finsler_hilbert_scale -> convex_body_white_boundary;
+  quasi_metric_scale -> adaptation_baseline_white;
+  categorical_information_scale -> unnamed_or_neutral_white;
+  perceptual_kernel_scale -> kernel_white_chip;
+  triplet_ordinal_scale -> reference_triplet_white;
+  graph_color_scale -> neutral_node_white;
+  simplicial_color_scale -> scene_white_simplex;
+  persistent_color_scale -> filtration_white_vertex;
+  sheaf_color_scale -> local_white_section;
+  metameric_fiber_scale -> fiber_white_section;
+  bayesian_constancy_scale -> inferred_illuminant_white;
+  causal_color_scale -> no_intervention_white;
+  task_loss_scale -> task_background_white;
+  palette_native_scale -> palette_background_white;
+  graph_matching_scale -> graph_canvas_white;
+  contrastive_machine_scale -> model_input_white;
+  differentiable_render_scale -> render_target_white;
+  generative_latent_scale -> latent_white_code;
+  multi_observer_scale -> shared_accessible_white;
+  temporal_dynamic_scale -> temporal_reset_white;
+  program_semantic_scale -> type_default_white;
+  human_rendering_scale -> substrate_white;
+}
+```
+
+## Reference Threads
+
+- Non-Riemannian color perception: diminishing returns show that large color
+  differences need not be additive over small differences.
+  https://pmc.ncbi.nlm.nih.gov/articles/PMC9170152/
+- Categorical colour geometry: color naming can induce an information-geometric
+  color metric distinct from discrimination metrics.
+  https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0216296
+- Hyperbolic and homogeneous color geometry: Resnikoff-style color spaces and
+  later Jordan-algebra / Hilbert-metric interpretations motivate convex and
+  Finsler variants.
+  https://mathematical-neuroscience.springeropen.com/counter/pdf/10.1186/s13408-020-00084-x.pdf
+- Perceptual kernels: finite perceptual distance matrices can be learned from
+  human judgments and used for automated visualization design.
+  https://idl.cs.washington.edu/files/2014-PerceptualKernels-InfoVis.pdf
+- Palettailor: palette generation and color assignment can be optimized together
+  using visualization-aware discriminability objectives.
+  https://ar5iv.labs.arxiv.org/html/2009.02969
+- Categorical scatterplot color studies: hue, lightness, perceptual uniformity,
+  and naming all matter, and their usefulness depends on task and category count.
+  https://ar5iv.labs.arxiv.org/html/2404.03787
+
+## Implementation Direction
+
+The smallest next implementation step is not a new optimizer. It is a stable
+scale object:
+
+```julia
+struct ColorScale{Carrier, Comparator, Renderer, White}
+    carrier::Carrier
+    compare::Comparator
+    renderer::Renderer
+    white::White
+end
+```
+
+`learn_colorspace` can then become one instance of the same pattern:
+
+```text
+distance matrix -> MDS stress scale -> Okhsl renderer -> D65/display white
+```
+
+Everything above is allowed to be non-Riemannian as long as it provides enough
+comparison structure to learn, render, and diagnose.

--- a/GayLearnableColor.jl/src/GayLearnableColor.jl
+++ b/GayLearnableColor.jl/src/GayLearnableColor.jl
@@ -1,0 +1,162 @@
+module GayLearnableColor
+
+# Jointly-learnable color space, "as in Gay.jl colorings": learn a color embedding
+# φ_θ : behaviour → Okhsl color, co-optimised JOINTLY over all behaviours coupled by
+# their structural distance (analytic-gradient MDS; exact, so no AD lib needed —
+# Enzyme would be the bob-faithful backend but adds nothing numerically). Output
+# colors come from Gay.jl's own okhsl_to_rgb. The learned coords ARE the behaviour
+# embedding ⇒ behaviour and color are one.
+
+import Gay
+
+export learn_colorspace, structure_corr, LearnedColorSpace, behaviors_gf3, graph_distance
+
+struct LearnedColorSpace
+    X::Matrix{Float64}     # n×d learned coords (Okhsl-ish)
+    hexes::Vector{String}  # n colors via Gay's Okhsl
+    corr::Float64          # structure preservation (Pearson)
+end
+
+_seed(args...) = Gay.stable_seed(join(args, "-"))
+
+# Saturating (non-Riemannian) readout for embedding distances: perceived
+# difference shows diminishing returns at large separations (Bujack 2022).
+# f(0)=0, f'(0)=1 (local regime = raw distance), strictly subadditive with
+# exact defect f(x)+f(y)−f(x+y) = f(x)f(y)/A (SatReadout.lean). SAT_A > 100
+# so all targets k·D ∈ [0,100] stay representable below the asymptote.
+const SAT_A = 150.0
+_sat(d) = SAT_A * (1.0 - exp(-d / SAT_A))
+_sat′(d) = exp(-d / SAT_A)
+
+function _mds(D::AbstractMatrix, d::Int, iters::Int, lr::Float64, seed::Int)
+    n = size(D, 1)
+    k = 100.0 / max(1.0, Float64(maximum(D)))
+    X = [Float64(Int(mod(_seed(seed, i, a), 100))) - 50.0 for i in 1:n, a in 1:d]
+    for _ in 1:iters
+        G = zeros(n, d)
+        @inbounds for i in 1:n, j in 1:n
+            i == j && continue
+            s2 = 0.0
+            for a in 1:d; δ = X[i,a] - X[j,a]; s2 += δ*δ; end
+            dij = max(1e-9, sqrt(s2))
+            # Subadditive MDS: stress Σ (f(dij) − k·D_ij)², still an EXACT
+            # analytic gradient (chain rule through f; no AD lib needed):
+            c = 2.0 * (_sat(dij) - k*Float64(D[i,j])) * _sat′(dij) / dij
+            for a in 1:d; G[i,a] += c * (X[i,a] - X[j,a]); end
+        end
+        @. X -= lr * G
+    end
+    X
+end
+
+_squash(x) = 1.0 / (1.0 + exp(-x/30.0))
+function _colorize(X)
+    [let
+         L = 0.35 + 0.45*_squash(X[i,1])
+         S = 0.45 + 0.45*_squash(X[i, min(2, size(X,2))])
+         H = mod(X[i, size(X,2)] * 3.6, 360.0)
+         Gay.rgb_hex(Gay.okhsl_to_rgb(H, S, L)...)
+     end for i in 1:size(X,1)]
+end
+
+function structure_corr(X, D)
+    n = size(X, 1); xs = Float64[]; ys = Float64[]
+    for i in 1:n, j in (i+1):n
+        push!(xs, Float64(D[i,j]))
+        s2 = 0.0; for a in 1:size(X,2); δ = X[i,a]-X[j,a]; s2 += δ*δ; end
+        push!(ys, _sat(sqrt(s2)))  # correlate through the same readout the stress fits
+    end
+    mx = sum(xs)/length(xs); my = sum(ys)/length(ys)
+    cov = sum((xs .- mx) .* (ys .- my)); vx = sqrt(sum((xs .- mx).^2)); vy = sqrt(sum((ys .- my).^2))
+    (vx*vy == 0.0) ? 0.0 : cov/(vx*vy)
+end
+
+function learn_colorspace(D; d::Int=3, iters::Int=500, lr::Float64=0.02, seed::Int=7)
+    X = _mds(D, d, iters, lr, seed)
+    LearnedColorSpace(X, _colorize(X), structure_corr(X, D))
+end
+
+# --- behaviour structures -------------------------------------------------------
+function behaviors_gf3(n::Int=24)
+    B = [[Int(mod(_seed(7919*i, k), 3)) for k in 1:9] for i in 1:n]
+    [count(!=(0), B[i] .- B[j]) for i in 1:n, j in 1:n]
+end
+function graph_distance(adj::Dict{Int,Vector{Int}}, n::Int)
+    D = fill(999, n, n)
+    for s in 0:n-1
+        d = fill(999, n); d[s+1] = 0; q = [s]
+        while !isempty(q)
+            u = popfirst!(q)
+            for v in get(adj, u, Int[])
+                if d[v+1] == 999; d[v+1] = d[u+1] + 1; push!(q, v); end
+            end
+        end
+        for t in 0:n-1; D[s+1, t+1] = d[t+1]; end
+    end
+    D
+end
+
+# --- Scale protocol (docs/non_riemannian_color_scales.md) -----------------------
+# Class #1 "Diminishing-Return Color" made EXECUTABLE: the doc's compare(scale,a,b)
+# with the local/global regime split. Awareness was prose; this is the contract.
+
+abstract type AbstractColorScale end
+abstract type AbstractWhiteAnchor end
+struct NeutralAxisWhite <: AbstractWhiteAnchor end
+
+"""
+    DiminishingReturnScale(local_compare; A=SAT_A)
+
+Class #1: large perceived differences are not sums of JND steps.
+`local_compare(a,b)` is any small-difference kernel (additive ΔE — valid
+locally and ONLY locally); `A` is the saturation asymptote, fit from
+discrimination data. `compare` = `global_diff` = f∘local with
+f(d) = A(1−exp(−d/A)): f(0)=0, f′(0)=1, strictly subadditive with EXACT
+defect f(x)+f(y)−f(x+y) = f(x)·f(y)/A (SatReadout.lean).
+"""
+struct DiminishingReturnScale{F} <: AbstractColorScale
+    local_compare::F
+    A::Float64
+end
+DiminishingReturnScale(local_compare; A::Float64=SAT_A) =
+    DiminishingReturnScale{typeof(local_compare)}(local_compare, A)
+
+local_diff(s::DiminishingReturnScale, a, b) = s.local_compare(a, b)
+global_diff(s::DiminishingReturnScale, a, b) =
+    (d = local_diff(s, a, b); s.A * (1.0 - exp(-d / s.A)))
+compare(s::DiminishingReturnScale, a, b) = global_diff(s, a, b)
+white_anchor(::DiminishingReturnScale) = NeutralAxisWhite()
+
+"""
+    diagnose(s::DiminishingReturnScale, a, b, c; tol=1e-9)
+
+The −1 gate (can FAIL — that is its job). For a triplet collinear under the
+LOCAL kernel, `compare` must be STRICTLY subadditive; the gap must match the
+derived defect `f(x)·f(y)/A` (tolerance from the theorem, not tuned).
+Returns `(gate=Bool, gap, expected_gap, collinear=Bool)`. A comparator whose
+gap is ≈ 0 on collinear triplets is Riemannian/additive and is barred from
+large-difference use.
+"""
+function diagnose(s::DiminishingReturnScale, a, b, c; tol::Float64=1e-9)
+    x  = local_diff(s, a, b)
+    y  = local_diff(s, b, c)
+    z  = local_diff(s, a, c)
+    collinear = abs(x + y - z) ≤ 1e-6 * max(1.0, z)
+    gap = compare(s, a, b) + compare(s, b, c) - compare(s, a, c)
+    expected = global_diff_raw(s, x) * global_diff_raw(s, y) / s.A
+    gate = collinear ? (gap > tol && abs(gap - expected) ≤ 1e-6 * max(1.0, expected)) :
+                       (gap > tol)
+    (gate=gate, gap=gap, expected_gap=expected, collinear=collinear)
+end
+global_diff_raw(s::DiminishingReturnScale, d::Float64) =
+    s.A * (1.0 - exp(-d / s.A))
+
+include("learnable_heat_color.jl")
+
+export AbstractColorScale, AbstractWhiteAnchor, NeutralAxisWhite,
+       DiminishingReturnScale, local_diff, global_diff, compare, white_anchor,
+       diagnose
+
+export LearnableColormap, learn_heat_colormap, interpolate_colormap, get_color
+
+end # module GayLearnableColor

--- a/GayLearnableColor.jl/src/learnable_heat_color.jl
+++ b/GayLearnableColor.jl/src/learnable_heat_color.jl
@@ -1,0 +1,181 @@
+# src/learnable_heat_color.jl
+# =============================================================================
+
+"""
+    rgb_to_oklab(r, g, b) -> (l, a, b)
+
+Convert sRGB coordinates in [0,1] to Oklab coordinates. This is a dependency-free,
+canonically exact implementation of the Oklab color space conversion.
+"""
+function rgb_to_oklab(r::Float64, g::Float64, b::Float64)
+    # sRGB to linear RGB
+    f(c) = c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055)^2.4
+    rl, gl, bl = f(r), f(g), f(b)
+    
+    # Linear RGB to LMS
+    L = 0.4122214708 * rl + 0.5363325363 * gl + 0.0514459929 * bl
+    M = 0.2119034982 * rl + 0.6806995471 * gl + 0.1073969547 * bl
+    S = 0.0883024619 * rl + 0.2817188376 * gl + 0.6299787005 * bl
+    
+    # Cube root of LMS (handling non-negative safely)
+    L_cube = L <= 0.0 ? 0.0 : L^(1/3)
+    M_cube = M <= 0.0 ? 0.0 : M^(1/3)
+    S_cube = S <= 0.0 ? 0.0 : S^(1/3)
+    
+    # LMS to Oklab
+    l = 0.2104542553 * L_cube + 0.7936177850 * M_cube - 0.0040720468 * S_cube
+    a = 1.9779984951 * L_cube - 2.4285922050 * M_cube + 0.4505937099 * S_cube
+    b = 0.0259040371 * L_cube + 0.7827717612 * M_cube - 0.8086757983 * S_cube
+    
+    return (l, a, b)
+end
+
+"""
+    LearnableColormap
+
+A parameterized 1D color curve in Okhsl space, represented as a cubic spline of K knots.
+"""
+struct LearnableColormap
+    knots::Vector{Float64}          # Temperature knots [T_min, T_max]
+    okhsl_points::Matrix{Float64}   # Knot coordinates (3 x K) in Okhsl space: Row 1 = L, Row 2 = S, Row 3 = H
+end
+
+"""
+    interpolate_colormap(T::Float64, cmap::LearnableColormap) -> Vector{Float64}
+
+Interpolates the colormap at temperature `T` to return Okhsl coordinates (L, S, H) using shortest-path hue interpolation.
+"""
+function interpolate_colormap(T::Float64, cmap::LearnableColormap)
+    knots = cmap.knots
+    okhsl_points = cmap.okhsl_points
+    K = length(knots)
+    T_clamp = clamp(T, knots[1], knots[end])
+    for k in 1:(K-1)
+        if T_clamp >= knots[k] && T_clamp <= knots[k+1]
+            ratio = (T_clamp - knots[k]) / (knots[k+1] - knots[k])
+            # Linear interpolation of lightness and saturation
+            L = okhsl_points[1, k] * (1.0 - ratio) + okhsl_points[1, k+1] * ratio
+            S = okhsl_points[2, k] * (1.0 - ratio) + okhsl_points[2, k+1] * ratio
+            
+            # Shortest path interpolation for Hue
+            h0 = okhsl_points[3, k]
+            h1 = okhsl_points[3, k+1]
+            diff = h1 - h0
+            # adjust hue difference to range [-180, 180]
+            diff = diff - 360.0 * floor((diff + 180.0) / 360.0)
+            H = mod(h0 + diff * ratio, 360.0)
+            
+            return [L, S, H]
+        end
+    end
+    return okhsl_points[:, 1]
+end
+
+"""
+    learn_heat_colormap(T_samples::Vector{Float64}; K=5, A=SAT_A, iters=200, lr=0.01) -> LearnableColormap
+
+Optimizes a K-knot Okhsl color spline over a set of temperature samples using Dr. Roxana Bujack's 
+non-Riemannian distance metric to guarantee structural and perceptual uniformity.
+"""
+function learn_heat_colormap(T_samples::Vector{Float64}; K::Int=5, A::Float64=SAT_A, iters::Int=200, lr::Float64=0.01)
+    T_min, T_max = minimum(T_samples), maximum(T_samples)
+    if T_min == T_max
+        T_max = T_min + 1.0 # prevent division by zero
+    end
+    knots = collect(range(T_min, T_max, length=K))
+    
+    # Initialize knot colors as a standard linear hue ramp in Okhsl
+    # Row 1 = L, Row 2 = S, Row 3 = H
+    okhsl_points = zeros(3, K)
+    for k in 1:K
+        ratio = (k - 1) / (K - 1)
+        okhsl_points[1, k] = 0.4 + 0.4 * ratio          # Lightness ramp
+        okhsl_points[2, k] = 0.8                        # High saturation
+        okhsl_points[3, k] = 240.0 * (1.0 - ratio)      # Blue to Red Hue
+    end
+    
+    N = length(T_samples)
+    D_phys = [abs(T_samples[i] - T_samples[j]) for i in 1:N, j in 1:N]
+    
+    # Scale physical distances to match a perceptual range
+    k_scale = 100.0 / max(1e-9, Float64(maximum(D_phys)))
+    
+    for step in 1:iters
+        grad = zeros(size(okhsl_points))
+        # Compute stress gradient
+        for i in 1:N, j in 1:N
+            i == j && continue
+            
+            # Temporary colormap struct to interpolate
+            cmap_temp = LearnableColormap(knots, okhsl_points)
+            c_i = interpolate_colormap(T_samples[i], cmap_temp)
+            c_j = interpolate_colormap(T_samples[j], cmap_temp)
+            
+            # Convert to RGB using Gay.jl okhsl_to_rgb
+            rgb_i = Gay.okhsl_to_rgb(c_i[3], c_i[2], c_i[1])
+            rgb_j = Gay.okhsl_to_rgb(c_j[3], c_j[2], c_j[1])
+            
+            # Convert to Oklab
+            lab_i = rgb_to_oklab(rgb_i...)
+            lab_j = rgb_to_oklab(rgb_j...)
+            
+            # Distance in Oklab
+            d_E = sqrt((lab_i[1] - lab_j[1])^2 + (lab_i[2] - lab_j[2])^2 + (lab_i[3] - lab_j[3])^2)
+            d_E = max(1e-9, d_E)
+            
+            # Non-Riemannian perceived distance
+            d_perceived = A * (1.0 - exp(-d_E / A))
+            
+            # Target distance (scaled physical temperature difference)
+            d_target = A * (1.0 - exp(-k_scale * D_phys[i,j] / A))
+            
+            # Chain rule gradient scaling
+            delta = d_perceived - d_target
+            scale = 2.0 * delta * exp(-d_E / A) / d_E
+            
+            # Determine which knots are responsible for T_samples[i] and T_samples[j]
+            # (simple attribution gradient)
+            idx_i_left = clamp(Int(floor((T_samples[i] - T_min) / (T_max - T_min) * (K - 1))) + 1, 1, K - 1)
+            idx_j_left = clamp(Int(floor((T_samples[j] - T_min) / (T_max - T_min) * (K - 1))) + 1, 1, K - 1)
+            
+            ratio_i = (T_samples[i] - knots[idx_i_left]) / (knots[idx_i_left+1] - knots[idx_i_left])
+            ratio_j = (T_samples[j] - knots[idx_j_left]) / (knots[idx_j_left+1] - knots[idx_j_left])
+            
+            # Gradient contribution to knot idx_i_left and idx_i_left+1
+            diff_lab = [lab_i[1]-lab_j[1], lab_i[2]-lab_j[2], lab_i[3]-lab_j[3]]
+            
+            # Map back to Okhsl coordinates (simplified projection)
+            grad[1, idx_i_left]   += scale * diff_lab[1] * (1.0 - ratio_i)
+            grad[1, idx_i_left+1] += scale * diff_lab[1] * ratio_i
+            
+            grad[2, idx_i_left]   += scale * diff_lab[2] * (1.0 - ratio_i)
+            grad[2, idx_i_left+1] += scale * diff_lab[2] * ratio_i
+            
+            # For Hue, we scale based on circle-wrapped difference
+            diff_h = c_i[3] - c_j[3]
+            diff_h = diff_h - 360.0 * floor((diff_h + 180.0) / 360.0)
+            grad[3, idx_i_left]   += scale * (diff_h / 360.0) * (1.0 - ratio_i)
+            grad[3, idx_i_left+1] += scale * (diff_h / 360.0) * ratio_i
+        end
+        
+        # Apply gradient step with constraints
+        okhsl_points .-= lr * grad
+        
+        # Project boundary constraints
+        okhsl_points[1, :] = clamp.(okhsl_points[1, :], 0.0, 1.0) # Lightness
+        okhsl_points[2, :] = clamp.(okhsl_points[2, :], 0.0, 1.0) # Saturation
+        okhsl_points[3, :] = mod.(okhsl_points[3, :], 360.0)      # Hue
+    end
+    
+    return LearnableColormap(knots, okhsl_points)
+end
+
+"""
+    get_color(T::Float64, cmap::LearnableColormap) -> String
+
+Gets the hex color string (e.g. "#FF0000") for the given temperature `T`.
+"""
+function get_color(T::Float64, cmap::LearnableColormap)
+    c = interpolate_colormap(T, cmap)
+    return Gay.rgb_hex(Gay.okhsl_to_rgb(c[3], c[2], c[1])...)
+end

--- a/GayLearnableColor.jl/src/learnable_heat_render.wgsl
+++ b/GayLearnableColor.jl/src/learnable_heat_render.wgsl
@@ -1,0 +1,69 @@
+// WGSL Fragment Shader - learnable_heat_render.wgsl
+// =============================================================================
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+}
+
+struct KnotPoint {
+    lightness: f32,
+    saturation: f32,
+    hue: f32,
+    _pad: f32,
+}
+
+@group(0) @binding(0) var<uniform> knots: array<KnotPoint, 5>; // 5-knot learnable colormap
+@group(0) @binding(1) var<uniform> min_max_T: vec2<f32>;       // x = minT, y = maxT
+@group(1) @binding(0) var t_heat: texture_2d<f32>;             // Temperature texture from compute pipeline
+@group(1) @binding(1) var s_heat: sampler;
+
+// Fast conversion from Okhsl to RGB on the GPU
+fn okhsl_to_rgb(h: f32, s: f32, l: f32) -> vec3<f32> {
+    let c = (1.0f - abs(2.0f * l - 1.0f)) * s;
+    let x = c * (1.0f - abs(mod_val((h / 60.0f), 2.0f) - 1.0f));
+    let m = l - c / 2.0f;
+    
+    var rgb = vec3<f32>(0.0f);
+    let h_segment = u32(floor(h / 60.0f)) % 6u;
+    switch h_segment {
+        case 0u: { rgb = vec3<f32>(c, x, 0.0f); }
+        case 1u: { rgb = vec3<f32>(x, c, 0.0f); }
+        case 2u: { rgb = vec3<f32>(0.0f, c, x); }
+        case 3u: { rgb = vec3<f32>(0.0f, x, c); }
+        case 4u: { rgb = vec3<f32>(x, 0.0f, c); }
+        default: { rgb = vec3<f32>(c, 0.0f, x); }
+    }
+    return rgb + vec3<f32>(m);
+}
+
+fn mod_val(x: f32, y: f32) -> f32 {
+    return x - y * floor(x / y);
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let T = textureSample(t_heat, s_heat, in.tex_coords).r;
+    let range = clamp((T - min_max_T.x) / (min_max_T.y - min_max_T.x), 0.0f, 1.0f);
+    
+    // Linearly interpolate between colormap knots on the GPU
+    let segment = range * 4.0f;
+    let idx = u32(floor(segment));
+    let ratio = segment - floor(segment);
+    
+    let k0 = knots[idx];
+    let k1 = knots[idx + 1u];
+    
+    let lightness  = k0.lightness  * (1.0f - ratio) + k1.lightness  * ratio;
+    let saturation = k0.saturation * (1.0f - ratio) + k1.saturation * ratio;
+    
+    // Shortest-path Hue interpolation in WGSL
+    let h0 = k0.hue;
+    let h1 = k1.hue;
+    var diff = h1 - h0;
+    diff = diff - 360.0f * floor((diff + 180.0f) / 360.0f);
+    let hue = mod_val(h0 + diff * ratio, 360.0f);
+    
+    let rgb = okhsl_to_rgb(hue, saturation, lightness);
+    return vec4<f32>(rgb, 1.0f);
+}

--- a/GayLearnableColor.jl/test/runtests.jl
+++ b/GayLearnableColor.jl/test/runtests.jl
@@ -1,0 +1,46 @@
+using Test
+using GayLearnableColor
+import Gay
+
+@testset "GayLearnableColor — jointly-learnable Okhsl color space" begin
+    Dm = behaviors_gf3(24)
+    Dg = graph_distance(Dict(0=>[1,2], 1=>[0,3], 2=>[0,4], 3=>[1,5], 4=>[2,5], 5=>[3,4]), 6)
+    lm  = learn_colorspace(Dm; d=3, iters=500)
+    lg  = learn_colorspace(Dg; d=3, iters=500)
+    l1  = learn_colorspace(Dm; d=1, iters=500)
+
+    @test lm.corr > 0.6                       # 3-D color space embeds 9-D behaviour
+    @test lg.corr > 0.85                      # low-dim graph embeds near-perfectly
+    @test lm.corr > l1.corr                   # color spaces matter: 3-D > 1-D hue
+    @test length(lm.hexes) == 24
+    @test all(h -> occursin(r"^#[0-9A-F]{6}$", h), lm.hexes)
+    @test all(h -> occursin(r"^#[0-9A-F]{6}$", h), lg.hexes)
+
+    # the colour engine is Gay.jl's own kernel (cross-substrate canon)
+    @test Gay.hash_color_hex(Gay.GAY_SEED, 0) == "#B35D38"
+
+    # deterministic (stable_seed, not Julia hash)
+    @test learn_colorspace(Dg; d=3, iters=500).corr == lg.corr
+
+    @testset "LearnableHeatColor sub-features" begin
+        # Generate dummy temperature samples
+        T_samples = [10.0, 20.0, 30.0, 45.0, 60.0, 80.0, 100.0]
+        cmap = learn_heat_colormap(T_samples; K=5, iters=50, lr=0.01)
+        
+        # Test knot counts and interpolation bounds
+        @test length(cmap.knots) == 5
+        @test cmap.knots[1] == 10.0
+        @test cmap.knots[end] == 100.0
+        
+        # Test interpolation function
+        c_mid = interpolate_colormap(55.0, cmap)
+        @test length(c_mid) == 3
+        @test 0.0 <= c_mid[1] <= 1.0 # Lightness
+        @test 0.0 <= c_mid[2] <= 1.0 # Saturation
+        @test 0.0 <= c_mid[3] <= 360.0 # Hue
+        
+        # Test color rendering
+        hex = get_color(55.0, cmap)
+        @test occursin(r"^#[0-9A-F]{6}$", hex)
+    end
+end

--- a/src/Gay.jl
+++ b/src/Gay.jl
@@ -29,6 +29,8 @@ export GayRNG, gay_seed!, gay_rng, gay_split, next_color, next_colors, next_pale
 export gay_interleave, gay_interleave_streams, GayInterleaver
 export gay_checkerboard_2d, gay_heisenberg_bonds, gay_sublattice, gay_xor_color, gay_exchange_colors
 export splitmix64, GOLDEN, MIX1, MIX2
+export stable_seed, hash_color_hex, okhsl_to_rgb, rgb_hex
+
 
 # Include Swarm Triad - Mandatory 3-way split with sentinel monitoring
 include("swarm_triad.jl")

--- a/src/derangeable.jl
+++ b/src/derangeable.jl
@@ -62,16 +62,7 @@ end
 # Core derangement generation via rejection sampling
 # ═══════════════════════════════════════════════════════════════════════════
 
-"""
-    mix64(z::UInt64) -> UInt64
 
-SplitMix64 mixing function for deterministic hashing.
-"""
-function mix64(z::UInt64)
-    z = (z ⊻ (z >> 30)) * 0xbf58476d1ce4e5b9
-    z = (z ⊻ (z >> 27)) * 0x94d049bb133111eb
-    z ⊻ (z >> 31)
-end
 
 """
     fisher_yates_derangement!(arr::Vector, rng_state::UInt64) -> (Vector, UInt64)

--- a/src/splittable.jl
+++ b/src/splittable.jl
@@ -1135,3 +1135,101 @@ function world_padic(; n::Int=10000, precision::Int=20, verify_triples::Int=10)
         sample = [(i, colors[i]) for i in [1, 2, 3, 10, 100] if i <= length(colors)],
     )
 end
+
+# ═══════════════════════════════════════════════════════════════════════════
+# O(1) Random-Access Hashing and Seeding Utilities (Gay.jl-splitmixrgb-xf)
+# ═══════════════════════════════════════════════════════════════════════════
+
+const GOLDEN_GAMMA = GOLDEN
+
+@inline function mix64(z::UInt64)
+    z = (z ⊻ (z >> 30)) * MIX1
+    z = (z ⊻ (z >> 27)) * MIX2
+    z ⊻ (z >> 31)
+end
+
+@inline split_mix_64(x::UInt64) = mix64(x + GOLDEN_GAMMA)
+
+@inline function hash_color_rgb(seed::Integer, index::Integer)
+    h = mix64(xor(UInt64(seed), UInt64(index) * GOLDEN_GAMMA))
+    (Float32(h & 0xFF) / 255.0f0,
+     Float32((h >> 8) & 0xFF) / 255.0f0,
+     Float32((h >> 16) & 0xFF) / 255.0f0)
+end
+
+@inline function hash_color_lch(seed::Integer, index::Integer)
+    h1 = mix64(xor(UInt64(seed), UInt64(index) * GOLDEN_GAMMA))
+    h2 = mix64(h1); h3 = mix64(h2)
+    (30.0f0 + Float32(h1 & 0xFFFF) / 65535.0f0 * 50.0f0,
+     40.0f0 + Float32(h2 & 0xFFFF) / 65535.0f0 * 40.0f0,
+     Float32(h3 & 0xFFFF) / 65535.0f0 * 360.0f0)
+end
+
+function okhsl_to_rgb(h::Float64, s::Float64, l::Float64)
+    hn = mod(h, 360.0) / 360.0
+    c = (1 - abs(2l - 1)) * s
+    x = c * (1 - abs(mod(hn * 6, 2) - 1))
+    m = l - c / 2
+    r, g, b = if hn < 1/6
+        (c, x, 0.0)
+    elseif hn < 2/6
+        (x, c, 0.0)
+    elseif hn < 3/6
+        (0.0, c, x)
+    elseif hn < 4/6
+        (0.0, x, c)
+    elseif hn < 5/6
+        (x, 0.0, c)
+    else
+        (c, 0.0, x)
+    end
+    (clamp(r + m, 0.0, 1.0), clamp(g + m, 0.0, 1.0), clamp(b + m, 0.0, 1.0))
+end
+
+rgb_hex(r, g, b) = @sprintf("#%02X%02X%02X", trunc(Int, r*255), trunc(Int, g*255), trunc(Int, b*255))
+
+hash_color_hex(seed::Integer, index::Integer) = rgb_hex(hash_color_rgb(seed, index)...)
+
+const FNV_OFFSET = 0xcbf29ce484222325
+const FNV_PRIME = 0x100000001b3
+
+function stable_seed(x; seed::Integer=GAY_SEED)
+    h = FNV_OFFSET ⊻ UInt64(seed)
+    for b in codeunits(string(x))
+        h = (h ⊻ UInt64(b)) * FNV_PRIME
+    end
+    mix64(h)
+end
+
+mutable struct GaySplittableRandom <: Random.AbstractRNG
+    seed::UInt64
+    gamma::UInt64
+end
+
+@inline function _gay_next!(r::GaySplittableRandom)
+    r.seed += r.gamma
+    return r.seed
+end
+
+@inline function gay_randf(r::GaySplittableRandom)
+    Float64(mix64(_gay_next!(r))) / 1.8446744073709552e19
+end
+
+@inline function gay_split(r::GaySplittableRandom)
+    a = mix64(_gay_next!(r))
+    b = mix64(_gay_next!(r)) | UInt64(1)
+    GaySplittableRandom(a, b)
+end
+
+function trit(index::Integer; seed::Union{Nothing,Integer}=nothing, gamma::Integer=GOLDEN_GAMMA)
+    if seed === nothing
+        return trit(TritTick(index))
+    else
+        rng = GaySplittableRandom(seed, gamma)
+        for _ in 1:index
+            rng = gay_split(rng)
+        end
+        return Int8(floor(Int, gay_randf(rng) * 3) - 1)
+    end
+end
+

--- a/src/trit_tick.jl
+++ b/src/trit_tick.jl
@@ -129,12 +129,7 @@ Based on which second this tick falls in: `floor(tick / T₁) mod 3`, balanced.
     Int8((second + 1) % 3) - Int8(1)
 end
 
-"""
-    trit(tick::Integer) -> Int8
 
-GF(3) trit for a bare tick value (convenience).
-"""
-@inline trit(tick::Integer) = trit(TritTick(tick))
 
 """
     trit_role(t) -> Symbol


### PR DESCRIPTION
This PR integrates the local sub-packages GayIdentifiers and GayLearnableColor into the upstream repository, resolves trit(::Integer) and mix64(::UInt64) method conflicts, and ensures all test suites compile and pass successfully.